### PR TITLE
Resize Screen 프로젝트 추가

### DIFF
--- a/D3D11_1/21_ResizeScreen/21_ResizeScreen.vcxproj
+++ b/D3D11_1/21_ResizeScreen/21_ResizeScreen.vcxproj
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{0a49a7b7-b8df-478c-9773-c47e40ebe2b7}</ProjectGuid>
+    <RootNamespace>My21ResizeScreen</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <FxCompile Include="Shaders\PS_DepthOnlyPass.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+    </FxCompile>
+    <FxCompile Include="Shaders\PS_DirectionalLight.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+    </FxCompile>
+    <FxCompile Include="Shaders\PS_GBuffer.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+    </FxCompile>
+    <FxCompile Include="Shaders\PS_Skybox.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+    </FxCompile>
+    <FxCompile Include="Shaders\PS_Solid.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+    </FxCompile>
+    <FxCompile Include="Shaders\VS_DepthOnlyPass.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+    </FxCompile>
+    <FxCompile Include="Shaders\VS_DirectionalLight.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+    </FxCompile>
+    <FxCompile Include="Shaders\VS_GBuffer.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+    </FxCompile>
+    <FxCompile Include="Shaders\VS_Skybox.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">5.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">5.0</ShaderModel>
+    </FxCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Shaders\Shared.hlsli" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Animation.cpp" />
+    <ClCompile Include="Bone.cpp" />
+    <ClCompile Include="DebugDraw.cpp" />
+    <ClCompile Include="DeferredRenderApp.cpp" />
+    <ClCompile Include="FBXResourceManager.cpp" />
+    <ClCompile Include="Mesh.cpp" />
+    <ClCompile Include="SkeletalModel.cpp" />
+    <ClCompile Include="SkeletonInfo.cpp" />
+    <ClCompile Include="TextureLoader.cpp" />
+    <ClCompile Include="WinMain.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Animation.h" />
+    <ClInclude Include="AnimationKey.h" />
+    <ClInclude Include="Bone.h" />
+    <ClInclude Include="BoneAnimation.h" />
+    <ClInclude Include="DebugDraw.h" />
+    <ClInclude Include="DeferredRenderApp.h" />
+    <ClInclude Include="FBXImporter.h" />
+    <ClInclude Include="FBXResourceManager.h" />
+    <ClInclude Include="Mesh.h" />
+    <ClInclude Include="SkeletalModel.h" />
+    <ClInclude Include="SkeletonInfo.h" />
+    <ClInclude Include="TextureLoader.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.vcxproj">
+      <Project>{7db874a9-d4ca-457e-b8bc-3a1a56020163}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/D3D11_1/21_ResizeScreen/21_ResizeScreen.vcxproj.filters
+++ b/D3D11_1/21_ResizeScreen/21_ResizeScreen.vcxproj.filters
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="소스 파일">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="헤더 파일">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="리소스 파일">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <FxCompile Include="Shaders\PS_DepthOnlyPass.hlsl" />
+    <FxCompile Include="Shaders\PS_DirectionalLight.hlsl" />
+    <FxCompile Include="Shaders\PS_GBuffer.hlsl" />
+    <FxCompile Include="Shaders\PS_Skybox.hlsl" />
+    <FxCompile Include="Shaders\PS_Solid.hlsl" />
+    <FxCompile Include="Shaders\VS_DepthOnlyPass.hlsl" />
+    <FxCompile Include="Shaders\VS_DirectionalLight.hlsl" />
+    <FxCompile Include="Shaders\VS_GBuffer.hlsl" />
+    <FxCompile Include="Shaders\VS_Skybox.hlsl" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Shaders\Shared.hlsli" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Animation.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="Bone.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="DebugDraw.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="DeferredRenderApp.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="FBXResourceManager.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="Mesh.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="SkeletalModel.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="SkeletonInfo.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="TextureLoader.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="WinMain.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Animation.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="AnimationKey.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="Bone.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="BoneAnimation.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="DebugDraw.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="DeferredRenderApp.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="FBXImporter.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="FBXResourceManager.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="Mesh.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="SkeletalModel.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="SkeletonInfo.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="TextureLoader.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/D3D11_1/21_ResizeScreen/Animation.cpp
+++ b/D3D11_1/21_ResizeScreen/Animation.cpp
@@ -1,0 +1,36 @@
+#include "Animation.h"
+#include <stdexcept>
+
+void Animation::CreateBoneAnimation(aiAnimation* pAiAnimation)
+{
+	m_name = pAiAnimation->mName.C_Str();
+	m_tick = pAiAnimation->mTicksPerSecond;
+	m_duration = pAiAnimation->mDuration / m_tick;
+
+	// 본에 대한 키 애니메이션 저장
+	for (int i = 0; i < pAiAnimation->mNumChannels; i++)
+	{
+		aiNodeAnim* pAiNodeAnim = pAiAnimation->mChannels[i];
+
+		BoneAnimation boneAnim;
+		boneAnim.m_boneName = pAiNodeAnim->mNodeName.C_Str();
+		boneAnim.CreateKeys(pAiNodeAnim, m_tick);
+		m_boneAnimations.push_back(boneAnim);
+		m_mappingBoneAnimations.insert({ boneAnim.m_boneName, i });
+	}
+
+}
+
+bool Animation::GetBoneAnimationByName(string boneName, BoneAnimation& out)
+{
+	auto anim = m_mappingBoneAnimations.find(boneName);
+	if (anim == m_mappingBoneAnimations.end())
+	{
+		return false;
+	}
+
+	int index = anim->second;
+	out = m_boneAnimations[index];
+
+	return true;
+}

--- a/D3D11_1/21_ResizeScreen/Animation.h
+++ b/D3D11_1/21_ResizeScreen/Animation.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "BoneAnimation.h"
+#include <map>
+
+using namespace std;
+
+class Animation
+{
+public:
+	map<string, int> m_mappingBoneAnimations; 
+	vector<BoneAnimation> m_boneAnimations;		// 키 프레임에 등록된 본 위치와 시간 정보들
+	float m_duration;							// 최종 시간 ( 초 단위 )
+	string m_name;								// 애니메이션 이름
+	float m_tick;								// 애니메이션 틱
+
+	void CreateBoneAnimation(aiAnimation* pAiAnimation);
+	bool GetBoneAnimationByName(string boneName, BoneAnimation& out);
+};
+

--- a/D3D11_1/21_ResizeScreen/AnimationKey.h
+++ b/D3D11_1/21_ResizeScreen/AnimationKey.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <directxtk/SimpleMath.h>
+
+using namespace DirectX::SimpleMath;
+
+class AnimationKey
+{
+public:
+	float m_time;			// 키 프레임 시간
+	Vector3 m_position;		// 아마 해당 본의 상대적 위치일 것으로 추정
+	Quaternion m_rotation;	// 
+	Vector3 m_scale;		// 
+};

--- a/D3D11_1/21_ResizeScreen/Bone.cpp
+++ b/D3D11_1/21_ResizeScreen/Bone.cpp
@@ -1,0 +1,11 @@
+#include "Bone.h"
+
+void Bone::CreateBone(string objName, int parentIndex, int boneIndex, Matrix worldMat, Matrix localMat)
+{
+	name = objName;
+	m_parentIndex = parentIndex;
+	m_index = boneIndex;
+
+	m_worldTransform = worldMat;
+	m_localTransform = localMat;
+}

--- a/D3D11_1/21_ResizeScreen/Bone.h
+++ b/D3D11_1/21_ResizeScreen/Bone.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <string>
+#include <directxtk/SimpleMath.h>
+#include "BoneAnimation.h"
+
+using namespace std;
+using namespace DirectX::SimpleMath;
+
+class Bone
+{
+public:
+	void CreateBone(string objName, int parentIndex, int boneIndex, Matrix worldMat, Matrix localMat);
+
+	BoneAnimation m_boneAnimation;	// 
+
+// private: -> 편의를 위해 public 설정
+	Matrix m_worldTransform;
+	Matrix m_localTransform;
+
+	string name = "";		// 해당 bone의 이름
+
+	int m_parentIndex = -1; // 계층 구조에서의 부모 인덱스
+	int m_index = -1;		// 
+};

--- a/D3D11_1/21_ResizeScreen/BoneAnimation.h
+++ b/D3D11_1/21_ResizeScreen/BoneAnimation.h
@@ -1,0 +1,89 @@
+#pragma once
+#include <vector>
+#include <algorithm>
+#include <assimp\scene.h>
+#include "AnimationKey.h"
+
+
+using namespace std;
+
+class BoneAnimation
+{
+public:
+	string m_boneName;				// 사용하는 본 이름
+	vector<AnimationKey> m_keys;	// 채널(mChaneels)에 저장되어 있는 키 값들
+	// string interpolationType		
+
+	void CreateKeys(aiNodeAnim* pAiNodeAnim, float perTick)
+	{
+		// 일단 키 값들 개수와 각 키에 대한 시간이 모두 동일하다고 가정하고 작성
+		int keyNum = pAiNodeAnim->mNumPositionKeys;
+		for (int i = 0; i < keyNum; i++)
+		{
+			AnimationKey key;
+			key.m_time = pAiNodeAnim->mPositionKeys[i].mTime / perTick;
+			key.m_position =
+			{
+				pAiNodeAnim->mPositionKeys[i].mValue.x,
+				pAiNodeAnim->mPositionKeys[i].mValue.y,
+				pAiNodeAnim->mPositionKeys[i].mValue.z
+			};
+
+			key.m_rotation =
+			{
+				pAiNodeAnim->mRotationKeys[i].mValue.x,
+				pAiNodeAnim->mRotationKeys[i].mValue.y,
+				pAiNodeAnim->mRotationKeys[i].mValue.z,
+				pAiNodeAnim->mRotationKeys[i].mValue.w
+			};
+
+			key.m_scale =
+			{
+				pAiNodeAnim->mScalingKeys[i].mValue.x,
+				pAiNodeAnim->mScalingKeys[i].mValue.y,
+				pAiNodeAnim->mScalingKeys[i].mValue.z
+			};
+
+			m_keys.push_back(key);
+		}
+	}
+
+	template <typename T>
+	T Clamp(T value, T min, T max)
+	{
+		return (value < min) ? min : (value > max) ? max : value;
+	}
+
+	void Evaluate(float time, Vector3& outPosition, Quaternion& outRotation, Vector3& outScale)
+	{
+		if (m_keys.size() < 2) // check has anim
+			return;
+
+		// 키프레임 쌍 탐색
+		size_t index = 1;
+		while (index + 1 < m_keys.size() && time >= m_keys[index + 1].m_time) // 보간 종료 지점 찾기 ( index + 1 )
+		{
+			index++;
+		}
+
+		// 인덱스 범위 확인
+		if (index + 1 >= m_keys.size())
+		{
+			index = m_keys.size() - 2;
+		}
+
+		const auto& keyA = m_keys[index];			// 보간 시작 지점
+		const auto& keyB = m_keys[index + 1];		// 보간 종료 지점
+
+		float duration = keyB.m_time - keyA.m_time;	// 유효한 지점인지 검사
+		if (duration <= 0.0f) return;
+
+		float t = (time - keyA.m_time) / duration;
+		t = Clamp(t, 0.0f, 1.0f);
+
+		// calcuate out datas
+		outPosition = Vector3::Lerp(keyA.m_position, keyB.m_position, t);
+		outRotation = Quaternion::Slerp(keyA.m_rotation, keyB.m_rotation, t);
+		outScale = Vector3::Lerp(keyA.m_scale, keyB.m_scale, t);
+	};
+};

--- a/D3D11_1/21_ResizeScreen/DebugDraw.cpp
+++ b/D3D11_1/21_ResizeScreen/DebugDraw.cpp
@@ -1,0 +1,293 @@
+//--------------------------------------------------------------------------------------
+// File: DebugDraw.cpp
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//-------------------------------------------------------------------------------------
+
+#include "DebugDraw.h"
+#include <algorithm>
+
+using namespace DirectX;
+
+namespace
+{
+    inline void XM_CALLCONV DrawCube(PrimitiveBatch<VertexPositionColor>* batch,
+        CXMMATRIX matWorld,
+        FXMVECTOR color)
+    {
+        static const XMVECTORF32 s_verts[8] =
+        {
+            { { { -1.f, -1.f, -1.f, 0.f } } },
+            { { {  1.f, -1.f, -1.f, 0.f } } },
+            { { {  1.f, -1.f,  1.f, 0.f } } },
+            { { { -1.f, -1.f,  1.f, 0.f } } },
+            { { { -1.f,  1.f, -1.f, 0.f } } },
+            { { {  1.f,  1.f, -1.f, 0.f } } },
+            { { {  1.f,  1.f,  1.f, 0.f } } },
+            { { { -1.f,  1.f,  1.f, 0.f } } }
+        };
+
+        static const WORD s_indices[] =
+        {
+            0, 1,
+            1, 2,
+            2, 3,
+            3, 0,
+            4, 5,
+            5, 6,
+            6, 7,
+            7, 4,
+            0, 4,
+            1, 5,
+            2, 6,
+            3, 7
+        };
+
+        VertexPositionColor verts[8];
+        for (size_t i = 0; i < 8; ++i)
+        {
+            const XMVECTOR v = XMVector3Transform(s_verts[i], matWorld);
+            XMStoreFloat3(&verts[i].position, v);
+            XMStoreFloat4(&verts[i].color, color);
+        }
+
+        batch->DrawIndexed(D3D_PRIMITIVE_TOPOLOGY_LINELIST, s_indices, static_cast<UINT>(std::size(s_indices)), verts, 8);
+    }
+}
+
+void XM_CALLCONV DX::Draw(PrimitiveBatch<VertexPositionColor>* batch,
+    const BoundingSphere& sphere,
+    FXMVECTOR color)
+{
+    const XMVECTOR origin = XMLoadFloat3(&sphere.Center);
+
+    const float radius = sphere.Radius;
+
+    const XMVECTOR xaxis = XMVectorScale(g_XMIdentityR0, radius);
+    const XMVECTOR yaxis = XMVectorScale(g_XMIdentityR1, radius);
+    const XMVECTOR zaxis = XMVectorScale(g_XMIdentityR2, radius);
+
+    DrawRing(batch, origin, xaxis, zaxis, color);
+    DrawRing(batch, origin, xaxis, yaxis, color);
+    DrawRing(batch, origin, yaxis, zaxis, color);
+}
+
+void XM_CALLCONV DX::Draw(PrimitiveBatch<VertexPositionColor>* batch,
+    const BoundingBox& box,
+    FXMVECTOR color)
+{
+    XMMATRIX matWorld = XMMatrixScaling(box.Extents.x, box.Extents.y, box.Extents.z);
+    const XMVECTOR position = XMLoadFloat3(&box.Center);
+    matWorld.r[3] = XMVectorSelect(matWorld.r[3], position, g_XMSelect1110);
+
+    DrawCube(batch, matWorld, color);
+}
+
+void XM_CALLCONV DX::Draw(PrimitiveBatch<VertexPositionColor>* batch,
+    const BoundingOrientedBox& obb,
+    FXMVECTOR color)
+{
+    XMMATRIX matWorld = XMMatrixRotationQuaternion(XMLoadFloat4(&obb.Orientation));
+    const XMMATRIX matScale = XMMatrixScaling(obb.Extents.x, obb.Extents.y, obb.Extents.z);
+    matWorld = XMMatrixMultiply(matScale, matWorld);
+    const XMVECTOR position = XMLoadFloat3(&obb.Center);
+    matWorld.r[3] = XMVectorSelect(matWorld.r[3], position, g_XMSelect1110);
+
+    DrawCube(batch, matWorld, color);
+}
+
+void XM_CALLCONV DX::Draw(PrimitiveBatch<VertexPositionColor>* batch,
+    const BoundingFrustum& frustum,
+    FXMVECTOR color)
+{
+    XMFLOAT3 corners[BoundingFrustum::CORNER_COUNT];
+    frustum.GetCorners(corners);
+
+    VertexPositionColor verts[24] = {};
+    verts[0].position = corners[0];
+    verts[1].position = corners[1];
+    verts[2].position = corners[1];
+    verts[3].position = corners[2];
+    verts[4].position = corners[2];
+    verts[5].position = corners[3];
+    verts[6].position = corners[3];
+    verts[7].position = corners[0];
+
+    verts[8].position = corners[0];
+    verts[9].position = corners[4];
+    verts[10].position = corners[1];
+    verts[11].position = corners[5];
+    verts[12].position = corners[2];
+    verts[13].position = corners[6];
+    verts[14].position = corners[3];
+    verts[15].position = corners[7];
+
+    verts[16].position = corners[4];
+    verts[17].position = corners[5];
+    verts[18].position = corners[5];
+    verts[19].position = corners[6];
+    verts[20].position = corners[6];
+    verts[21].position = corners[7];
+    verts[22].position = corners[7];
+    verts[23].position = corners[4];
+
+    for (size_t j = 0; j < std::size(verts); ++j)
+    {
+        XMStoreFloat4(&verts[j].color, color);
+    }
+
+    batch->Draw(D3D_PRIMITIVE_TOPOLOGY_LINELIST, verts, static_cast<UINT>(std::size(verts)));
+}
+
+void XM_CALLCONV DX::DrawGrid(PrimitiveBatch<VertexPositionColor>* batch,
+    FXMVECTOR xAxis,
+    FXMVECTOR yAxis,
+    FXMVECTOR origin,
+    size_t xdivs,
+    size_t ydivs,
+    GXMVECTOR color)
+{
+    xdivs = std::max<size_t>(1, xdivs);
+    ydivs = std::max<size_t>(1, ydivs);
+
+    for (size_t i = 0; i <= xdivs; ++i)
+    {
+        float percent = float(i) / float(xdivs);
+        percent = (percent * 2.f) - 1.f;
+        XMVECTOR scale = XMVectorScale(xAxis, percent);
+        scale = XMVectorAdd(scale, origin);
+
+        const VertexPositionColor v1(XMVectorSubtract(scale, yAxis), color);
+        const VertexPositionColor v2(XMVectorAdd(scale, yAxis), color);
+        batch->DrawLine(v1, v2);
+    }
+
+    for (size_t i = 0; i <= ydivs; i++)
+    {
+        FLOAT percent = float(i) / float(ydivs);
+        percent = (percent * 2.f) - 1.f;
+        XMVECTOR scale = XMVectorScale(yAxis, percent);
+        scale = XMVectorAdd(scale, origin);
+
+        const VertexPositionColor v1(XMVectorSubtract(scale, xAxis), color);
+        const VertexPositionColor v2(XMVectorAdd(scale, xAxis), color);
+        batch->DrawLine(v1, v2);
+    }
+}
+
+void XM_CALLCONV DX::DrawRing(PrimitiveBatch<VertexPositionColor>* batch,
+    FXMVECTOR origin,
+    FXMVECTOR majorAxis,
+    FXMVECTOR minorAxis,
+    GXMVECTOR color)
+{
+    constexpr size_t c_ringSegments = 32;
+
+    VertexPositionColor verts[c_ringSegments + 1];
+
+    constexpr float fAngleDelta = XM_2PI / float(c_ringSegments);
+    // Instead of calling cos/sin for each segment we calculate
+    // the sign of the angle delta and then incrementally calculate sin
+    // and cosine from then on.
+    const XMVECTOR cosDelta = XMVectorReplicate(cosf(fAngleDelta));
+    const XMVECTOR sinDelta = XMVectorReplicate(sinf(fAngleDelta));
+    XMVECTOR incrementalSin = XMVectorZero();
+    static const XMVECTORF32 s_initialCos =
+    {
+        { { 1.f, 1.f, 1.f, 1.f } }
+    };
+    XMVECTOR incrementalCos = s_initialCos.v;
+    for (size_t i = 0; i < c_ringSegments; i++)
+    {
+        XMVECTOR pos = XMVectorMultiplyAdd(majorAxis, incrementalCos, origin);
+        pos = XMVectorMultiplyAdd(minorAxis, incrementalSin, pos);
+        XMStoreFloat3(&verts[i].position, pos);
+        XMStoreFloat4(&verts[i].color, color);
+        // Standard formula to rotate a vector.
+        const XMVECTOR newCos = XMVectorSubtract(XMVectorMultiply(incrementalCos, cosDelta), XMVectorMultiply(incrementalSin, sinDelta));
+        const XMVECTOR newSin = XMVectorAdd(XMVectorMultiply(incrementalCos, sinDelta), XMVectorMultiply(incrementalSin, cosDelta));
+        incrementalCos = newCos;
+        incrementalSin = newSin;
+    }
+    verts[c_ringSegments] = verts[0];
+
+    batch->Draw(D3D_PRIMITIVE_TOPOLOGY_LINESTRIP, verts, c_ringSegments + 1);
+}
+
+void XM_CALLCONV DX::DrawRay(PrimitiveBatch<VertexPositionColor>* batch,
+    FXMVECTOR origin,
+    FXMVECTOR direction,
+    bool normalize,
+    FXMVECTOR color)
+{
+    VertexPositionColor verts[3];
+    XMStoreFloat3(&verts[0].position, origin);
+
+    XMVECTOR normDirection = XMVector3Normalize(direction);
+    XMVECTOR rayDirection = (normalize) ? normDirection : direction;
+
+    XMVECTOR perpVector = XMVector3Cross(normDirection, g_XMIdentityR1);
+
+    if (XMVector3Equal(XMVector3LengthSq(perpVector), g_XMZero))
+    {
+        perpVector = XMVector3Cross(normDirection, g_XMIdentityR2);
+    }
+    perpVector = XMVector3Normalize(perpVector);
+
+    XMStoreFloat3(&verts[1].position, XMVectorAdd(rayDirection, origin));
+    perpVector = XMVectorScale(perpVector, 0.0625f);
+    normDirection = XMVectorScale(normDirection, -0.25f);
+    rayDirection = XMVectorAdd(perpVector, rayDirection);
+    rayDirection = XMVectorAdd(normDirection, rayDirection);
+    XMStoreFloat3(&verts[2].position, XMVectorAdd(rayDirection, origin));
+
+    XMStoreFloat4(&verts[0].color, color);
+    XMStoreFloat4(&verts[1].color, color);
+    XMStoreFloat4(&verts[2].color, color);
+
+    batch->Draw(D3D_PRIMITIVE_TOPOLOGY_LINESTRIP, verts, 2);
+}
+
+void XM_CALLCONV DX::DrawTriangle(PrimitiveBatch<VertexPositionColor>* batch,
+    FXMVECTOR pointA,
+    FXMVECTOR pointB,
+    FXMVECTOR pointC,
+    GXMVECTOR color)
+{
+    VertexPositionColor verts[4];
+    XMStoreFloat3(&verts[0].position, pointA);
+    XMStoreFloat3(&verts[1].position, pointB);
+    XMStoreFloat3(&verts[2].position, pointC);
+    XMStoreFloat3(&verts[3].position, pointA);
+
+    XMStoreFloat4(&verts[0].color, color);
+    XMStoreFloat4(&verts[1].color, color);
+    XMStoreFloat4(&verts[2].color, color);
+    XMStoreFloat4(&verts[3].color, color);
+
+    batch->Draw(D3D_PRIMITIVE_TOPOLOGY_LINESTRIP, verts, 4);
+}
+
+void XM_CALLCONV DX::DrawQuad(PrimitiveBatch<VertexPositionColor>* batch,
+    FXMVECTOR pointA,
+    FXMVECTOR pointB,
+    FXMVECTOR pointC,
+    GXMVECTOR pointD,
+    HXMVECTOR color)
+{
+    VertexPositionColor verts[5];
+    XMStoreFloat3(&verts[0].position, pointA);
+    XMStoreFloat3(&verts[1].position, pointB);
+    XMStoreFloat3(&verts[2].position, pointC);
+    XMStoreFloat3(&verts[3].position, pointD);
+    XMStoreFloat3(&verts[4].position, pointA);
+
+    XMStoreFloat4(&verts[0].color, color);
+    XMStoreFloat4(&verts[1].color, color);
+    XMStoreFloat4(&verts[2].color, color);
+    XMStoreFloat4(&verts[3].color, color);
+    XMStoreFloat4(&verts[4].color, color);
+
+    batch->Draw(D3D_PRIMITIVE_TOPOLOGY_LINESTRIP, verts, 5);
+}

--- a/D3D11_1/21_ResizeScreen/DebugDraw.h
+++ b/D3D11_1/21_ResizeScreen/DebugDraw.h
@@ -1,0 +1,55 @@
+//--------------------------------------------------------------------------------------
+// File: DebugDraw.h
+//
+// Helpers for drawing various debug shapes using PrimitiveBatch
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//-------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <directxtk/VertexTypes.h>      // https://github.com/microsoft/DirectXTK/wiki/VertexTypes
+#include <directxtk/PrimitiveBatch.h>   // https://github.com/microsoft/DirectXTK/wiki/PrimitiveBatch
+#include <DirectXColors.h>
+#include <DirectXCollision.h>
+
+namespace DX
+{
+    void XM_CALLCONV Draw(DirectX::PrimitiveBatch<DirectX::VertexPositionColor>* batch,
+        const DirectX::BoundingSphere& sphere,
+        DirectX::FXMVECTOR color = DirectX::Colors::White);
+
+    void XM_CALLCONV Draw(DirectX::PrimitiveBatch<DirectX::VertexPositionColor>* batch,
+        const DirectX::BoundingBox& box,
+        DirectX::FXMVECTOR color = DirectX::Colors::White);
+
+    void XM_CALLCONV Draw(DirectX::PrimitiveBatch<DirectX::VertexPositionColor>* batch,
+        const DirectX::BoundingOrientedBox& obb,
+        DirectX::FXMVECTOR color = DirectX::Colors::White);
+
+    void XM_CALLCONV Draw(DirectX::PrimitiveBatch<DirectX::VertexPositionColor>* batch,
+        const DirectX::BoundingFrustum& frustum,
+        DirectX::FXMVECTOR color = DirectX::Colors::White);
+
+    void XM_CALLCONV DrawGrid(DirectX::PrimitiveBatch<DirectX::VertexPositionColor>* batch,
+        DirectX::FXMVECTOR xAxis, DirectX::FXMVECTOR yAxis,
+        DirectX::FXMVECTOR origin, size_t xdivs, size_t ydivs,
+        DirectX::GXMVECTOR color = DirectX::Colors::White);
+
+    void XM_CALLCONV DrawRing(DirectX::PrimitiveBatch<DirectX::VertexPositionColor>* batch,
+        DirectX::FXMVECTOR origin, DirectX::FXMVECTOR majorAxis, DirectX::FXMVECTOR minorAxis,
+        DirectX::GXMVECTOR color = DirectX::Colors::White);
+
+    void XM_CALLCONV DrawRay(DirectX::PrimitiveBatch<DirectX::VertexPositionColor>* batch,
+        DirectX::FXMVECTOR origin, DirectX::FXMVECTOR direction, bool normalize = true,
+        DirectX::FXMVECTOR color = DirectX::Colors::White);
+
+    void XM_CALLCONV DrawTriangle(DirectX::PrimitiveBatch<DirectX::VertexPositionColor>* batch,
+        DirectX::FXMVECTOR pointA, DirectX::FXMVECTOR pointB, DirectX::FXMVECTOR pointC,
+        DirectX::GXMVECTOR color = DirectX::Colors::White);
+
+    void XM_CALLCONV DrawQuad(DirectX::PrimitiveBatch<DirectX::VertexPositionColor>* batch,
+        DirectX::FXMVECTOR pointA, DirectX::FXMVECTOR pointB, DirectX::FXMVECTOR pointC, DirectX::GXMVECTOR pointD,
+        DirectX::HXMVECTOR color = DirectX::Colors::White);
+}

--- a/D3D11_1/21_ResizeScreen/DeferredRenderApp.cpp
+++ b/D3D11_1/21_ResizeScreen/DeferredRenderApp.cpp
@@ -473,9 +473,11 @@ void DeferredRenderApp::CreateGbuffers()
 	}
 }
 
+
+
 void DeferredRenderApp::ResizeScreen(int width, int height)
 {
-	if (m_hWnd) return;
+	if (!m_hWnd) return;
 
 	m_ClientWidth = max(width, 1);
 	m_ClientHeight = max(height, 1);
@@ -520,6 +522,36 @@ void DeferredRenderApp::ResizeResource()
 
 	HR_T(m_device->CreateTexture2D(&dsDesc, nullptr, depthStencil.GetAddressOf()));
 	HR_T(m_device->CreateDepthStencilView(depthStencil.Get(), nullptr, m_depthStencilView.ReleaseAndGetAddressOf()));
+
+	// viewport 재설정
+	m_RenderViewport = {};
+	m_RenderViewport.TopLeftX = 0;
+	m_RenderViewport.TopLeftY = 0;
+	m_RenderViewport.Width = (float)m_ClientWidth;
+	m_RenderViewport.Height = (float)m_ClientHeight;
+	m_RenderViewport.MinDepth = 0.0f;
+	m_RenderViewport.MaxDepth = 1.0f;
+	m_deviceContext->RSSetViewports(1, &m_RenderViewport);
+
+	// 기존 gbuffer 초기화
+	ResetGBuffers();
+
+	// 사이즈에 맞는 gbuffer 생성
+	CreateGbuffers();
+
+	// 사이즈에 맞는 투영값 갱신
+	m_Projection = XMMatrixPerspectiveFovLH(m_PovAngle, m_ClientWidth / (FLOAT)m_ClientHeight, m_Near, m_Far);
+}
+
+void DeferredRenderApp::ResetGBuffers()
+{
+
+	for (int i = 0; i < gbufferCount; i++)
+	{
+		m_gBufferRTV[i].Reset();
+		m_gBufferSRV[i].Reset();
+		m_gBufferTextures[i].Reset();
+	}
 }
 
 bool DeferredRenderApp::OnInitialize()

--- a/D3D11_1/21_ResizeScreen/DeferredRenderApp.cpp
+++ b/D3D11_1/21_ResizeScreen/DeferredRenderApp.cpp
@@ -473,54 +473,54 @@ void DeferredRenderApp::CreateGbuffers()
 	}
 }
 
-//void DeferredRenderApp::ResizeScreen(int width, int height)
-//{
-//	if (m_hWnd) return;
-//
-//	m_ClientWidth = max(width, 1);
-//	m_ClientHeight = max(height, 1);
-//
-//	ResizeResource();
-//}
-//
-//void DeferredRenderApp::ResizeResource()
-//{
-//	// Clear
-//	m_deviceContext->OMSetRenderTargets(0, nullptr, nullptr);
-//	m_backbufferRTV.Reset();
-//	m_depthStencilView.Reset();
-//	m_deviceContext->Flush();		 // ??
-//
-//	const UINT backBufferWidth = static_cast<UINT>(m_ClientWidth);
-//	const UINT backBufferHeight = static_cast<UINT>(m_ClientHeight);
-//	const DXGI_FORMAT backBufferFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
-//	const DXGI_FORMAT depthBufferFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
-//	constexpr UINT backBufferCount = 2;
-//
-//	if (m_swapChain) // check swapchain exist
-//	{
-//		// 스왑체인 리사이즈
-//		HR_T(m_swapChain->ResizeBuffers(backBufferCount, backBufferWidth, backBufferHeight, backBufferFormat, 0));
-//	}
-//	else
-//	{
-//		return; // -> 해당 함수 사용시 스왑체인이 있다고 가정한다.
-//	}
-//
-//	// 백버퍼 생성
-//	ComPtr<ID3D11Texture2D> backBuffer;
-//	HR_T(m_swapChain->GetBuffer(0, IID_PPV_ARGS(backBuffer.GetAddressOf())));
-//
-//	// 백버퍼 rtv 생성
-//	HR_T(m_device->CreateRenderTargetView(backBuffer.Get(), nullptr, m_backbufferRTV.GetAddressOf()));
-//
-//	// dsv 생성
-//	CD3D11_TEXTURE2D_DESC dsDesc(depthBufferFormat, backBufferWidth, backBufferHeight, 1, 1, D3D11_BIND_DEPTH_STENCIL);
-//	ComPtr<ID3D11Texture2D> depthStencil;
-//
-//	HR_T(m_device->CreateTexture2D(&dsDesc, nullptr, depthStencil.GetAddressOf()));
-//	HR_T(m_device->CreateDepthStencilView(depthStencil.Get(), nullptr, m_depthStencilView.ReleaseAndGetAddressOf()));
-//}
+void DeferredRenderApp::ResizeScreen(int width, int height)
+{
+	if (m_hWnd) return;
+
+	m_ClientWidth = max(width, 1);
+	m_ClientHeight = max(height, 1);
+
+	ResizeResource();
+}
+
+void DeferredRenderApp::ResizeResource()
+{
+	// Clear
+	m_deviceContext->OMSetRenderTargets(0, nullptr, nullptr);
+	m_backbufferRTV.Reset();
+	m_depthStencilView.Reset();
+	m_deviceContext->Flush();		 // ??
+
+	const UINT backBufferWidth = static_cast<UINT>(m_ClientWidth);
+	const UINT backBufferHeight = static_cast<UINT>(m_ClientHeight);
+	const DXGI_FORMAT backBufferFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
+	const DXGI_FORMAT depthBufferFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
+	constexpr UINT backBufferCount = 2;
+
+	if (m_swapChain) // check swapchain exist
+	{
+		// 스왑체인 리사이즈
+		HR_T(m_swapChain->ResizeBuffers(backBufferCount, backBufferWidth, backBufferHeight, backBufferFormat, 0));
+	}
+	else
+	{
+		return; // -> 해당 함수 사용시 스왑체인이 있다고 가정한다.
+	}
+
+	// 백버퍼 생성
+	ComPtr<ID3D11Texture2D> backBuffer;
+	HR_T(m_swapChain->GetBuffer(0, IID_PPV_ARGS(backBuffer.GetAddressOf())));
+
+	// 백버퍼 rtv 생성
+	HR_T(m_device->CreateRenderTargetView(backBuffer.Get(), nullptr, m_backbufferRTV.GetAddressOf()));
+
+	// dsv 생성
+	CD3D11_TEXTURE2D_DESC dsDesc(depthBufferFormat, backBufferWidth, backBufferHeight, 1, 1, D3D11_BIND_DEPTH_STENCIL);
+	ComPtr<ID3D11Texture2D> depthStencil;
+
+	HR_T(m_device->CreateTexture2D(&dsDesc, nullptr, depthStencil.GetAddressOf()));
+	HR_T(m_device->CreateDepthStencilView(depthStencil.Get(), nullptr, m_depthStencilView.ReleaseAndGetAddressOf()));
+}
 
 bool DeferredRenderApp::OnInitialize()
 {
@@ -1366,23 +1366,23 @@ LRESULT DeferredRenderApp::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARA
 	if (ImGui_ImplWin32_WndProcHandler(hWnd, message, wParam, lParam))
 		return true;
 
-	//switch (message)
-	//{
-	//case WM_ENTERSIZEMOVE:
-	//	screenIsSizeMove = true;
-	//	break;
-	//case WM_EXITSIZEMOVE:
-	//	screenIsSizeMove = false;
-	//	if (m_pInstance)
-	//	{
-	//		RECT rc;
-	//		GetClientRect(hWnd, &rc);
-	//		ResizeScreen(rc.right - rc.left, rc.bottom - rc.top);
-	//	}
-	//	break;
-	//default:
-	//	break;
-	//}
+	switch (message)
+	{
+	case WM_ENTERSIZEMOVE:
+		screenIsSizeMove = true;
+		break;
+	case WM_EXITSIZEMOVE:
+		screenIsSizeMove = false;
+		if (m_pInstance)
+		{
+			RECT rc;
+			GetClientRect(hWnd, &rc);
+			ResizeScreen(rc.right - rc.left, rc.bottom - rc.top);
+		}
+		break;
+	default:
+		break;
+	}
 
 	return __super::WndProc(hWnd, message, wParam, lParam);
 }

--- a/D3D11_1/21_ResizeScreen/DeferredRenderApp.cpp
+++ b/D3D11_1/21_ResizeScreen/DeferredRenderApp.cpp
@@ -1,0 +1,1427 @@
+#include "DeferredRenderApp.h"
+#include "../Common/Helper.h"
+
+#include <directxtk/SimpleMath.h>
+#include <dxgidebug.h>
+#include <dxgi1_4.h>
+#include <dxgi1_6.h>
+#include <algorithm>
+
+#pragma comment(lib, "d3d11.lib")
+#pragma comment(lib, "dxgi.lib")
+#pragma comment(lib, "dxguid.lib")
+#pragma comment(lib, "d3dcompiler.lib")
+
+#include <string>
+#include <directxtk/DDSTextureLoader.h>
+
+using namespace DirectX::SimpleMath;
+using namespace DirectX;
+using Microsoft::WRL::ComPtr;
+
+#define USE_FLIPMODE 1 // 경고 메세지를 없애려면 Flip 모드를 사용한다.
+
+// 상수 버퍼
+struct ConstantBuffer
+{
+	// camera
+	Matrix cameraView;
+	Matrix cameraProjection;
+
+	// 
+	Matrix shadowView;
+	Matrix shadowProjection;
+
+	Vector4 ambient;	// 환경광
+	Vector4 diffuse;	// 난반사
+	Vector4 specular;	// 정반사
+	FLOAT shininess;	// 광택지수
+	Vector3 CameraPos;	// 카메라 위치
+
+	// PBR
+	FLOAT metalness;	//  
+	FLOAT roughness;	//
+	FLOAT lightIntensity;
+	FLOAT pad1;
+
+	Color baseColor;
+};
+
+struct LightDirectionCB
+{
+	Vector4 lightDirection;
+	Color lightColor;
+};
+
+struct CubeVertex
+{
+	Vector3 position;
+};
+
+struct QuadVertex
+{
+	Vector3 position;
+	Vector2 uv;
+
+	QuadVertex(float x, float y, float z, float u, float v) : position(x, y, z), uv(u, v) {}
+	QuadVertex(Vector3 p, Vector2 u) : position(p), uv(u) {}
+};
+
+std::string WStringToUTF8(const std::wstring& wstr)
+{
+	int sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(),
+		(int)wstr.size(),
+		nullptr, 0, nullptr, nullptr);
+
+	std::string result(sizeNeeded, 0);
+
+	WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(),
+		(int)wstr.size(),
+		&result[0], sizeNeeded,
+		nullptr, nullptr);
+
+	return result;
+}
+
+DeferredRenderApp::DeferredRenderApp(HINSTANCE hInstance)
+	: GameApp(hInstance)
+{
+	gbufferCount = static_cast<int>(EGbuffer::Count);
+}
+
+DeferredRenderApp::~DeferredRenderApp()
+{
+	UninitImGUI();
+}
+
+void DeferredRenderApp::InitDebugDraw()
+{
+	m_states = std::make_unique<CommonStates>(m_device.Get());
+	m_batch = std::make_unique<PrimitiveBatch<VertexPositionColor>>(m_deviceContext.Get());
+
+	m_effect = std::make_unique<BasicEffect>(m_device.Get());
+	m_effect->SetVertexColorEnabled(true);
+	m_effect->SetView(m_shadowView);
+	m_effect->SetProjection(m_shadowProj);
+
+	{
+		void const* shaderByteCode;
+		size_t byteCodeLength;
+
+		m_effect->GetVertexShaderBytecode(&shaderByteCode, &byteCodeLength); // ??
+
+		// https://github.com/Microsoft/DirectXTK/wiki/throwIfFailed -> 이거 문서에 있던건데 이거 결국 HRESULT 값을 반환한다는 소리임
+		HR_T(m_device->CreateInputLayout(
+			VertexPositionColor::InputElements, VertexPositionColor::InputElementCount,
+			shaderByteCode, byteCodeLength,
+			m_debugDrawInputLayout.ReleaseAndGetAddressOf()));
+	}
+}
+
+void DeferredRenderApp::InitShdowMap()
+{
+	// create shadow map texure desc
+	D3D11_TEXTURE2D_DESC texDesc = {}; // https://learn.microsoft.com/ko-kr/windows/win32/api/d3d11/ns-d3d11-d3d11_texture2d_desc
+	texDesc.Width = (UINT)m_shadowViewport.width;
+	texDesc.Height = (UINT)m_shadowViewport.height;
+	texDesc.MipLevels = 1;
+	texDesc.ArraySize = 1;
+	texDesc.Usage = D3D11_USAGE_DEFAULT;
+	texDesc.Format = DXGI_FORMAT_R32_TYPELESS;
+	texDesc.BindFlags = D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE;
+	texDesc.SampleDesc.Count = 1;
+	texDesc.SampleDesc.Quality = 0;
+	HR_T(m_device->CreateTexture2D(&texDesc, nullptr, m_shadowMap.GetAddressOf()));
+
+	// DSV
+	D3D11_DEPTH_STENCIL_VIEW_DESC descDSV = {};
+	descDSV.Format = DXGI_FORMAT_D32_FLOAT;
+	descDSV.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2D;
+	HR_T(m_device->CreateDepthStencilView(m_shadowMap.Get(), &descDSV, m_shadowMapDSV.GetAddressOf()));
+
+	// SRV
+	D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+	srvDesc.Format = DXGI_FORMAT_R32_FLOAT;
+	srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+	srvDesc.Texture2D.MipLevels = 1;
+	HR_T(m_device->CreateShaderResourceView(m_shadowMap.Get(), &srvDesc, m_shadowMapSRV.GetAddressOf()));
+
+	// 빛 계산 ( pov )
+	m_shadowProj = XMMatrixPerspectiveFovLH(m_shadowFrustumAngle, m_shadowViewport.width / (FLOAT)m_shadowViewport.height, m_shadowNear, m_shadowFar); // 그림자 절두체
+	m_shadowLookAt = m_Camera.m_Position + m_Camera.GetForward() * m_shadowForwardDistFromCamera;	// 바라보는 방향 = 카메라 위치 + 카메라 바라보는 방향으로부터 떨어진 태양의 위치
+	m_shadowPos = m_Camera.m_Position + ((Vector3)-m_LightDirection * m_shadowUpDistFromLookAt);	// 위치
+	m_shadowView = XMMatrixLookAtLH(m_shadowPos, m_shadowLookAt, Vector3(0.0f, 1.0f, 0.0f));
+}
+
+bool DeferredRenderApp::InitSkyBox()
+{
+	const float width = 1.0f;
+	const float height = 1.0f;
+	const float depth = 1.0f;
+	CubeVertex skyboxVertices[] =
+	{
+		{ Vector3(-width, -height, -depth) },
+		{ Vector3(-width, +height, -depth) },
+		{ Vector3(+width, +height, -depth) },
+		{ Vector3(+width, -height, -depth) },
+
+		{ Vector3(-width, -height, +depth) },
+		{ Vector3(+width, -height, +depth) },
+		{ Vector3(+width, +height, +depth) },
+		{ Vector3(-width, +height, +depth) },
+
+		{ Vector3(-width, +height, -depth) },
+		{ Vector3(-width, +height, +depth) },
+		{ Vector3(+width, +height, +depth) },
+		{ Vector3(+width, +height, -depth) },
+
+		{ Vector3(-width, -height, -depth) },
+		{ Vector3(+width, -height, -depth) },
+		{ Vector3(+width, -height, +depth) },
+		{ Vector3(-width, -height, +depth) },
+
+		{ Vector3(-width, -height, +depth) },
+		{ Vector3(-width, +height, +depth) },
+		{ Vector3(-width, +height, -depth) },
+		{ Vector3(-width, -height, -depth) },
+
+		{ Vector3(+width, -height, -depth) },
+		{ Vector3(+width, +height, -depth) },
+		{ Vector3(+width, +height, +depth) },
+		{ Vector3(+width, -height, +depth) }
+	};
+
+	// 버텍스 버퍼
+	D3D11_BUFFER_DESC bufferDesc = {};
+	bufferDesc.ByteWidth = sizeof(CubeVertex) * ARRAYSIZE(skyboxVertices);
+	bufferDesc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+	bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+	bufferDesc.CPUAccessFlags = 0;
+
+	D3D11_SUBRESOURCE_DATA vbData = {};
+	vbData.pSysMem = skyboxVertices;
+	HR_T(m_device->CreateBuffer(&bufferDesc, &vbData, m_skyboxVertexBuffer.GetAddressOf()));
+
+	m_SkyboxVertexBufferStride = sizeof(CubeVertex); 	// 버텍스 버퍼의 정보
+	m_SkyboxVertexBufferOffset = 0;
+
+	// 파이프라인에 바인딩할 InputLayout 생성
+	D3D11_INPUT_ELEMENT_DESC layout[] =
+	{
+		{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+	};
+
+	ComPtr<ID3DBlob> vertexShaderBuffer = nullptr;
+	HR_T(CompileShaderFromFile(L"Shaders\\VS_Skybox.hlsl", "main", "vs_5_0", &vertexShaderBuffer));
+	HR_T(m_device->CreateInputLayout(layout, ARRAYSIZE(layout), vertexShaderBuffer->GetBufferPointer(), vertexShaderBuffer->GetBufferSize(), m_skyboxInputLayout.GetAddressOf()));
+
+	// 파이프 라인에 바인딩할 정점 셰이더 생성
+	HR_T(m_device->CreateVertexShader(vertexShaderBuffer->GetBufferPointer(), vertexShaderBuffer->GetBufferSize(), NULL, m_skyboxVS.GetAddressOf()));
+
+	// 인덱스 버퍼
+	WORD skyboxIndices[] =
+	{
+		0, 1, 2,
+		0, 2, 3,
+		4, 5, 6,
+		4, 6, 7,
+		8, 9, 10,
+		8, 10, 11,
+		12, 13, 14,
+		12, 14, 15,
+		16, 17, 18,
+		16, 18, 19,
+		20, 21, 22,
+		20, 22, 23,
+	};
+
+	bufferDesc.ByteWidth = sizeof(WORD) * ARRAYSIZE(skyboxIndices);
+	bufferDesc.BindFlags = D3D11_BIND_INDEX_BUFFER;
+	bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+	bufferDesc.CPUAccessFlags = 0;
+
+	m_SkyboxVertexBufferStride = sizeof(CubeVertex); 	// 버텍스 버퍼의 정보
+	m_SkyboxVertexBufferOffset = 0;
+
+	m_nSkyboxIndices = ARRAYSIZE(skyboxIndices); // 인덱스 개수 저장
+
+	D3D11_SUBRESOURCE_DATA ibData = {};
+	ibData.pSysMem = skyboxIndices;
+	HR_T(m_device->CreateBuffer(&bufferDesc, &ibData, m_skyboxIndexBuffer.GetAddressOf()));
+
+	// 픽셀 셰이더
+	ComPtr<ID3DBlob> sbPixelShaderBuffer = nullptr;
+	HR_T(CompileShaderFromFile(L"Shaders\\PS_Skybox.hlsl", "main", "ps_5_0", &sbPixelShaderBuffer));
+	HR_T(m_device->CreatePixelShader(sbPixelShaderBuffer->GetBufferPointer(), sbPixelShaderBuffer->GetBufferSize(), NULL, m_skyboxPS.GetAddressOf()));
+
+	// 래스터라이저
+	D3D11_RASTERIZER_DESC rasterizerState = {};
+	rasterizerState.CullMode = D3D11_CULL_BACK;
+	rasterizerState.FillMode = D3D11_FILL_SOLID;
+	rasterizerState.DepthClipEnable = true;
+	rasterizerState.FrontCounterClockwise = true;
+
+	HR_T(m_device->CreateRasterizerState(&rasterizerState, m_skyRasterizerState.ReleaseAndGetAddressOf()));
+
+	// 스카이 박스 뎊스 스텐실 상태 개체 추가
+	D3D11_DEPTH_STENCIL_DESC skyboxDsDesc{};
+	skyboxDsDesc.DepthEnable = true;
+	skyboxDsDesc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ZERO;	// 깊이 버퍼 사용 X
+	skyboxDsDesc.DepthFunc = D3D11_COMPARISON_LESS_EQUAL;		
+	skyboxDsDesc.StencilEnable = false;
+
+	HR_T(m_device->CreateDepthStencilState(&skyboxDsDesc, m_skyDepthStencilState.GetAddressOf()));
+
+	return true;
+}
+
+void DeferredRenderApp::CreateSwapchain()
+{
+	// 2. 스왑체인 생성을 위한 DXGI Factory 생성
+	UINT dxgiFactoryFlags = 0;
+
+#ifdef _DEBUG
+	dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+#endif // _DEBUG
+
+	DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
+#if USE_FLIPMODE == 1
+	swapChainDesc.BufferCount = 2;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD; // ??
+#else
+	swapChainDesc.BufferCount = 1;
+	swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+#endif
+	swapChainDesc.Width = m_ClientWidth;
+	swapChainDesc.Height = m_ClientHeight;
+
+	// 하나의 픽셀이 채널 RGBA 각 8비트 형식으로 표현
+	// Unsigned Normalized Integer 8비트 정수(0~255)단계를 부동소수점으로 정규화한 0.0~1.0으로 매핑하여 표현한다.
+	swapChainDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT; // 스왑 체인의 백 버퍼가 렌더링 파이프라인의 최종 출력 대상으로 사용
+	swapChainDesc.SampleDesc.Count = 1;	// 멀티 샘플링 사용 안함
+	swapChainDesc.AlphaMode = DXGI_ALPHA_MODE_IGNORE; // 투명도 조작 무시 | recommand for flip mode ?
+	swapChainDesc.Stereo = FALSE;
+	swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH; // 전체 화면 전환을 허용
+	swapChainDesc.Scaling = DXGI_SCALING_NONE; // 창의 크기와 백 버퍼의 크기가 다를 때. 백버퍼 크기에 맞게 스케일링 하지 않는다.
+
+	HR_T(CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&m_factory)));
+	HR_T(m_factory->CreateSwapChainForHwnd
+	(
+		m_device.Get(),
+		m_hWnd,
+		&swapChainDesc,
+		nullptr,
+		nullptr,
+		&m_swapChain
+	));
+
+	// 3. 랜더타겟 뷰 생성. 랜더타겟 뷰는 "여기에 그림을 그려라"라고 GPU에게 알려주는 역할을 하는 객체
+	// 텍스쳐와 영구적으로 연결되는 객체
+	ComPtr<ID3D11Texture2D> pBackBufferTexture;
+	HR_T(m_swapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (void**)&pBackBufferTexture));
+	HR_T(m_device->CreateRenderTargetView(pBackBufferTexture.Get(), nullptr, m_backbufferRTV.GetAddressOf()));
+
+	// ??
+	Microsoft::WRL::ComPtr<IDXGISwapChain3> swapChain3;
+	HR_T(m_swapChain->QueryInterface(__uuidof(IDXGISwapChain3), (void**)&swapChain3));
+}
+
+void DeferredRenderApp::DrawFrustum(Matrix worldMat, Matrix viewMat, Matrix proejctionMat,
+	float angle, float AspectRatio, float nearZ, float farZ, XMVECTORF32 color)
+{
+	Vector3 scale = { 1,1,1 };
+
+	// 절투체 만들기
+	BoundingFrustum frustum{};
+	BoundingFrustum::CreateFromMatrix(frustum, proejctionMat);
+
+	Matrix frustumWorld = viewMat.Transpose();
+
+	frustum.Transform(frustum, frustumWorld); // 위치 옮기기
+	frustum.Transform(frustum, worldMat);
+
+	m_effect->SetWorld(Matrix::Identity);	// 해당 그림 위치 설정
+	m_effect->SetView(m_View);				// 해당 그림을 어디 기준으로 그릴지 설정
+	m_effect->SetProjection(m_Projection);	// 해당 그림이 어디에 투영 될지 설정
+	m_effect->Apply(m_deviceContext.Get());
+
+	// 문서에 따른 세팅 -> https://github.com/microsoft/DirectXTK/wiki/DebugDraw
+	m_deviceContext->OMSetBlendState(m_states->Opaque(), nullptr, 0xFFFFFFFF);
+	m_deviceContext->OMSetDepthStencilState(m_states->DepthNone(), 0);
+	m_deviceContext->RSSetState(m_states->CullNone());
+
+	m_deviceContext->IASetInputLayout(m_debugDrawInputLayout.Get()); // 디버그용 InputLayout 적용
+
+	m_batch->Begin();
+	DX::Draw(m_batch.get(), frustum, color);
+
+	m_batch->End();
+}
+
+bool DeferredRenderApp::InitDxgi()
+{
+	// ============================================
+	// 1. IDXGIDevice3 생성
+	// ============================================
+	HR_T(m_device->QueryInterface(__uuidof(IDXGIDevice3), reinterpret_cast<void**>(dxgiDevice3.GetAddressOf())));
+
+
+	// ============================================
+	// 1. DXGI 어댑터 생성
+	// ============================================
+	HR_T((CreateDXGIFactory1(__uuidof(IDXGIFactory6), reinterpret_cast<void**>(dxgiFactory6.GetAddressOf()))));
+
+	HR_T(dxgiFactory6->EnumAdapters1(0, dxgiAdapter1.GetAddressOf()));
+
+	// ============================================
+	// 3. VRAM 사용량 (DXGI 1.4 - Windows 10+)
+	// ============================================
+	HR_T(dxgiAdapter1->QueryInterface(__uuidof(IDXGIAdapter3), reinterpret_cast<void**>(dxgiAdapter3.GetAddressOf())));
+
+	return true;
+}
+
+void DeferredRenderApp::CreateQuad()
+{
+	QuadVertex QuadVertices[] =
+	{
+		QuadVertex(Vector3(-1.0f,  1.0f, 1.0f), Vector2(0.0f,0.0f)),	// Left Top 
+		QuadVertex(Vector3(1.0f,  1.0f, 1.0f), Vector2(1.0f, 0.0f)),	// Right Top
+		QuadVertex(Vector3(-1.0f, -1.0f, 1.0f), Vector2(0.0f, 1.0f)),	// Left Bottom
+		QuadVertex(Vector3(1.0f, -1.0f, 1.0f), Vector2(1.0f, 1.0f))		// Right Bottom
+	};
+
+	D3D11_BUFFER_DESC vbDesc = {};
+	vbDesc.ByteWidth = sizeof(QuadVertex) * ARRAYSIZE(QuadVertices);
+	vbDesc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+	vbDesc.Usage = D3D11_USAGE_DEFAULT;
+	D3D11_SUBRESOURCE_DATA vbData = {};
+	vbData.pSysMem = QuadVertices;	// 배열 데이터 할당.
+	HR_T(m_device->CreateBuffer(&vbDesc, &vbData, &m_quadVertexBuffer));
+	m_quadVertexBufferStride = sizeof(QuadVertex);		// 버텍스 버퍼 정보
+	m_quadVertexBufferOffset = 0;
+
+	// InputLayout 생성 	
+	D3D11_INPUT_ELEMENT_DESC layout[] = // 입력 레이아웃.
+	{
+		{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0,  D3D11_INPUT_PER_VERTEX_DATA, 0 },
+		{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 }
+	};
+
+	ComPtr<ID3DBlob> vertexShaderBuffer{};
+	// Light Pass
+	vertexShaderBuffer.Reset();
+	HR_T(CompileShaderFromFile(L"Shaders\\VS_DirectionalLight.hlsl", "main", "vs_5_0", vertexShaderBuffer.GetAddressOf()));
+	HR_T(m_device->CreateInputLayout(layout, ARRAYSIZE(layout),vertexShaderBuffer->GetBufferPointer(), vertexShaderBuffer->GetBufferSize(), m_quadInputLayout.GetAddressOf()));
+	HR_T(m_device->CreateVertexShader(vertexShaderBuffer->GetBufferPointer(), vertexShaderBuffer->GetBufferSize(), NULL, m_directionalLightVS.GetAddressOf()));
+
+	// 인덱스 버퍼 생성
+	WORD indices[] =
+	{
+		0,1,2,
+		1,3,2
+	};
+	m_quadIndicesCount = ARRAYSIZE(indices);	// 인덱스 개수 저장.
+	D3D11_BUFFER_DESC ibDesc = {};
+	ibDesc.ByteWidth = sizeof(WORD) * ARRAYSIZE(indices);
+	ibDesc.BindFlags = D3D11_BIND_INDEX_BUFFER;
+	ibDesc.Usage = D3D11_USAGE_DEFAULT;
+	D3D11_SUBRESOURCE_DATA ibData = {};
+	ibData.pSysMem = indices;
+	HR_T(m_device->CreateBuffer(&ibDesc, &ibData, m_quadIndexBuffer.GetAddressOf()));
+}
+
+void DeferredRenderApp::CreateGbuffers()
+{
+	// gbuffer
+	m_gBufferRTV.assign(gbufferCount, {});
+	m_gBufferSRV.assign(gbufferCount, {});
+	m_gBufferTextures.assign(gbufferCount, {});
+	struct RTDesc
+	{
+		DXGI_FORMAT format;
+	};
+
+	vector<RTDesc> formats
+	{
+		{ DXGI_FORMAT_R8G8B8A8_UNORM_SRGB },	// BaseColor
+		{ DXGI_FORMAT_R8G8B8A8_UNORM },			// Normal
+		{ DXGI_FORMAT_R16G16B16A16_FLOAT },		// PositionWS 
+		{ DXGI_FORMAT_R8_UNORM },			// Metal
+		{ DXGI_FORMAT_R8_UNORM },			// rough
+		{ DXGI_FORMAT_R8_UNORM },			// specular
+		{ DXGI_FORMAT_R8G8B8A8_UNORM },			// emission
+	};
+
+
+	for (int i = 0; i < gbufferCount; i++)
+	{
+		D3D11_TEXTURE2D_DESC ds{};
+		ds.Width = m_ClientWidth;
+		ds.Height = m_ClientHeight;
+		ds.MipLevels = 1;
+		ds.ArraySize = 1;
+		ds.Format = formats[i].format;
+		ds.SampleDesc.Count = 1;
+		ds.Usage = D3D11_USAGE_DEFAULT;
+		ds.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+
+		HR_T(m_device->CreateTexture2D(&ds, nullptr, m_gBufferTextures[i].GetAddressOf()));
+		HR_T(m_device->CreateShaderResourceView(m_gBufferTextures[i].Get(), nullptr, m_gBufferSRV[i].GetAddressOf()));
+		HR_T(m_device->CreateRenderTargetView(m_gBufferTextures[i].Get(), nullptr, m_gBufferRTV[i].GetAddressOf()));
+	}
+}
+
+//void DeferredRenderApp::ResizeScreen(int width, int height)
+//{
+//	if (m_hWnd) return;
+//
+//	m_ClientWidth = max(width, 1);
+//	m_ClientHeight = max(height, 1);
+//
+//	ResizeResource();
+//}
+//
+//void DeferredRenderApp::ResizeResource()
+//{
+//	// Clear
+//	m_deviceContext->OMSetRenderTargets(0, nullptr, nullptr);
+//	m_backbufferRTV.Reset();
+//	m_depthStencilView.Reset();
+//	m_deviceContext->Flush();		 // ??
+//
+//	const UINT backBufferWidth = static_cast<UINT>(m_ClientWidth);
+//	const UINT backBufferHeight = static_cast<UINT>(m_ClientHeight);
+//	const DXGI_FORMAT backBufferFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
+//	const DXGI_FORMAT depthBufferFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
+//	constexpr UINT backBufferCount = 2;
+//
+//	if (m_swapChain) // check swapchain exist
+//	{
+//		// 스왑체인 리사이즈
+//		HR_T(m_swapChain->ResizeBuffers(backBufferCount, backBufferWidth, backBufferHeight, backBufferFormat, 0));
+//	}
+//	else
+//	{
+//		return; // -> 해당 함수 사용시 스왑체인이 있다고 가정한다.
+//	}
+//
+//	// 백버퍼 생성
+//	ComPtr<ID3D11Texture2D> backBuffer;
+//	HR_T(m_swapChain->GetBuffer(0, IID_PPV_ARGS(backBuffer.GetAddressOf())));
+//
+//	// 백버퍼 rtv 생성
+//	HR_T(m_device->CreateRenderTargetView(backBuffer.Get(), nullptr, m_backbufferRTV.GetAddressOf()));
+//
+//	// dsv 생성
+//	CD3D11_TEXTURE2D_DESC dsDesc(depthBufferFormat, backBufferWidth, backBufferHeight, 1, 1, D3D11_BIND_DEPTH_STENCIL);
+//	ComPtr<ID3D11Texture2D> depthStencil;
+//
+//	HR_T(m_device->CreateTexture2D(&dsDesc, nullptr, depthStencil.GetAddressOf()));
+//	HR_T(m_device->CreateDepthStencilView(depthStencil.Get(), nullptr, m_depthStencilView.ReleaseAndGetAddressOf()));
+//}
+
+bool DeferredRenderApp::OnInitialize()
+{
+	if (!InitD3D())
+		return false;
+
+	if (!InitScene())
+		return false;
+
+	if (!InitImGUI())
+		return false;
+
+	if (!InitEffect())
+		return false;
+
+	if (!InitSkyBox())
+		return false;
+
+	if (!InitDxgi())
+		return false;
+
+	CreateSwapchain();
+	InitShdowMap();
+	InitDebugDraw();
+	ResetValues();
+	CreateQuad();
+	CreateGbuffers();
+
+	return true;
+}
+
+void DeferredRenderApp::OnUpdate()
+{
+	float delta = GameTimer::m_Instance->DeltaTime();
+
+	Matrix scale = Matrix::Identity;
+	Matrix rotate = Matrix::Identity;
+	Matrix position = Matrix::Identity;
+
+	// Camera
+	m_Camera.GetCameraViewMatrix(m_View);
+
+	m_chara->Update();
+	m_ground->Update();
+	m_ground->m_Scale = m_GroundScale;
+	m_sphere->Update();
+
+	for (auto& e : m_models)
+	{
+		if (!e->isRemoved) e->Update();
+	}
+}
+
+void DeferredRenderApp::OnRender()
+{
+	// clear
+	Color color(0.0f, 0.0f, 0.0f, 0.0f);
+	m_deviceContext->ClearDepthStencilView(m_depthStencilView.Get(), D3D11_CLEAR_DEPTH, 1.0f, 0);
+	m_deviceContext->ClearRenderTargetView(m_backbufferRTV.Get(), color);
+
+	// GBuffer 초기화
+	int gbufferCount = static_cast<int>(EGbuffer::Count);
+	float clearValue[4] = { 0,0,0,0 };
+	for (int i = 0; i < gbufferCount; i++)
+	{
+		m_deviceContext->ClearRenderTargetView(m_gBufferRTV[i].Get(), clearValue);
+	}
+
+	DepthOnlyPass();
+	RenderPassGBuffer();
+	RenderPassDirectionalLight();
+	SkyboxPass(); 
+
+	RenderImGUI();
+
+	// 스왑체인 교체
+	m_swapChain->Present(0, 0);
+}
+
+bool isplayed = false;
+
+void DeferredRenderApp::RenderPassGBuffer()
+{
+	m_deviceContext->OMSetRenderTargets(gbufferCount, m_gBufferRTV.data()->GetAddressOf(), m_depthStencilView.Get());
+
+	// Update Constant Values
+	ConstantBuffer cb;
+	cb.cameraView = XMMatrixTranspose(m_View);
+	cb.cameraProjection = XMMatrixTranspose(m_Projection);
+	cb.shadowView = XMMatrixTranspose(m_shadowView);
+	cb.shadowProjection = XMMatrixTranspose(m_shadowProj);
+
+	cb.ambient = m_LightAmbient;
+	cb.diffuse = m_LightDiffuse;
+	cb.specular = m_LightSpecular;
+
+	cb.shininess = m_Shininess;
+	cb.CameraPos = m_Camera.m_Position;
+
+	cb.roughness = roughness;
+	cb.metalness = metalness;
+	cb.lightIntensity = lightIntensity;
+	cb.baseColor = BaseColor;
+
+	m_deviceContext->UpdateSubresource(m_constantBuffer.Get(), 0, nullptr, &cb, 0, 0);
+
+	// 텍스처 및 샘플링 설정 -> 초기화
+	m_deviceContext->IASetInputLayout(m_inputLayout.Get());
+	m_deviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+	m_deviceContext->VSSetShader(m_skinnedMeshVertexShader.Get(), 0, 0);
+	m_deviceContext->VSSetConstantBuffers(0, 1, m_constantBuffer.GetAddressOf());
+
+	m_deviceContext->RSSetState(m_rasterizerState.Get());
+	m_deviceContext->RSSetViewports(1, &m_RenderViewport); // 뷰포트 되돌리기
+
+	m_deviceContext->PSSetShader(m_PBRPS.Get(), 0, 0);
+	m_deviceContext->PSSetShaderResources(4, 1, m_shadowMapSRV.GetAddressOf());
+	m_deviceContext->PSSetConstantBuffers(0, 1, m_constantBuffer.GetAddressOf());
+	m_deviceContext->PSSetConstantBuffers(1, 1, m_materialBuffer.GetAddressOf());
+	m_deviceContext->PSSetSamplers(0, 1, m_samplerLinear.GetAddressOf());
+	m_deviceContext->PSSetSamplers(1, 1, m_samplerPoint.GetAddressOf());
+
+
+	m_deviceContext->OMSetDepthStencilState(m_depthStencilStateWriteOn.Get(), 1);
+
+
+	// Draw 
+	m_chara->Draw(m_deviceContext, m_materialBuffer);
+	m_ground->Draw(m_deviceContext, m_materialBuffer);
+	m_tree->Draw(m_deviceContext, m_materialBuffer);
+	m_sphere->Draw(m_deviceContext, m_materialBuffer);
+
+	for (auto& e : m_models)
+	{
+		e->Draw(m_deviceContext, m_materialBuffer);
+	}
+
+	// RTV Unbind 	
+	vector<ID3D11RenderTargetView*> nullRTVs(m_gBufferRTV.size(), {});
+	m_deviceContext->OMSetRenderTargets(gbufferCount, nullRTVs.data(), nullptr);
+}
+
+void DeferredRenderApp::RenderPassDirectionalLight()
+{
+	LightDirectionCB lightdirCB;
+	//m_LightDirection.Normalize();
+	lightdirCB.lightDirection = Vector4(m_LightDirection.x, m_LightDirection.y, m_LightDirection.z, lightIntensity);
+	lightdirCB.lightColor = m_LightColor;
+
+	ConstantBuffer cb;
+	cb.CameraPos = m_Camera.m_Position;
+	cb.shadowView = XMMatrixTranspose(m_shadowView);
+	cb.shadowProjection = XMMatrixTranspose(m_shadowProj);
+	// 11, 12, 13 -> color, normal, worldpos
+	// 4 shadow depth
+
+	// 처음 빛을 추가할 때 백버퍼 초기화
+	float blendFactor[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+	m_deviceContext->OMSetBlendState(m_additiveBlendState.Get(), blendFactor, 0xffffffff);
+	m_deviceContext->OMSetRenderTargets(1, m_backbufferRTV.GetAddressOf(), m_depthStencilView.Get());
+	m_deviceContext->OMSetDepthStencilState(m_depthStencilStateWriteOff.Get(), 0); // Depth test OFF, write OFF
+
+	vector<ID3D11ShaderResourceView*> SRVs =
+	{
+		m_gBufferSRV[0].Get(),
+		m_gBufferSRV[1].Get(),
+		m_gBufferSRV[2].Get(),
+		m_gBufferSRV[3].Get(),
+		m_gBufferSRV[4].Get()
+	};
+
+	m_deviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_deviceContext->IASetVertexBuffers(0, 1, m_quadVertexBuffer.GetAddressOf(), &m_quadVertexBufferStride, &m_quadVertexBufferOffset);
+	m_deviceContext->IASetIndexBuffer(m_quadIndexBuffer.Get(), DXGI_FORMAT_R16_UINT, 0);
+	m_deviceContext->IASetInputLayout(m_quadInputLayout.Get());
+
+	m_deviceContext->VSSetShader(m_directionalLightVS.Get(), nullptr, 0);
+
+	m_deviceContext->UpdateSubresource(m_lightDirectionBuffer.Get(), 0, nullptr, &lightdirCB, 0, 0);
+	m_deviceContext->PSSetConstantBuffers(5, 1, m_lightDirectionBuffer.GetAddressOf());
+	m_deviceContext->UpdateSubresource(m_constantBuffer.Get(), 0, nullptr, &cb, 0, 0);
+	m_deviceContext->PSSetConstantBuffers(0, 1, m_constantBuffer.GetAddressOf());
+
+	m_deviceContext->PSSetShaderResources(11, SRVs.size(), SRVs.data());			// gbuffer texture 바인드
+	m_deviceContext->PSSetShaderResources(4, 1, m_shadowMapSRV.GetAddressOf());	// shadow map 바인드
+	m_deviceContext->PSSetShaderResources(8, 1, m_IBLIrradiance.GetAddressOf());		// Irradiance
+	m_deviceContext->PSSetShaderResources(9, 1, m_IBLSpecular.GetAddressOf());		// Sepcular
+	m_deviceContext->PSSetShaderResources(10, 1, m_IBLLookUpTable.GetAddressOf());	// LUT
+
+	m_deviceContext->PSSetSamplers(0, 1, m_samplerLinear.GetAddressOf());
+	m_deviceContext->PSSetSamplers(1, 1, m_samplerLinear.GetAddressOf());
+	m_deviceContext->PSSetShader(m_directionalLightPS.Get(), nullptr, 0); 
+	m_deviceContext->DrawIndexed(m_quadIndicesCount, 0, 0);
+
+	m_deviceContext->OMSetBlendState(nullptr, blendFactor, 0xffffffff);
+	
+	// srv unbind
+	vector<ID3D11ShaderResourceView*> nullSRVs(SRVs.size(), nullptr);
+	m_deviceContext->PSSetShaderResources(11, SRVs.size(), nullSRVs.data());	// gbuffer tex
+
+	vector<ID3D11ShaderResourceView*> nullSRVs2(1, nullptr);
+	m_deviceContext->PSSetShaderResources(4, 1, nullSRVs2.data());				// shadow map
+}
+
+void DeferredRenderApp::SkyboxPass()
+{
+	// 카메라용 뷰 행렬과, 투영행렬
+	Matrix m_skyboxProjection = XMMatrixPerspectiveFovLH(m_PovAngle, m_ClientWidth / (FLOAT)m_ClientHeight, 0.1, m_Far);
+
+	// Update Constant Values
+	ConstantBuffer cb;
+	cb.cameraView = XMMatrixTranspose(m_View); // 쉐이더 코드 내부에서 이동 성분 제거함
+	cb.cameraProjection = XMMatrixTranspose(m_skyboxProjection);
+	cb.shadowView = XMMatrixTranspose(m_shadowView);
+	cb.shadowProjection = XMMatrixTranspose(m_shadowProj);
+
+
+	m_deviceContext->IASetVertexBuffers(0, 1, m_skyboxVertexBuffer.GetAddressOf(), &m_SkyboxVertexBufferStride, &m_SkyboxVertexBufferOffset);
+	m_deviceContext->IASetIndexBuffer(m_skyboxIndexBuffer.Get(), DXGI_FORMAT_R16_UINT, 0);
+	m_deviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_deviceContext->IASetInputLayout(m_skyboxInputLayout.Get());
+
+	m_deviceContext->VSSetShader(m_skyboxVS.Get(), nullptr, 0);
+	m_deviceContext->VSSetConstantBuffers(0, 1, m_constantBuffer.GetAddressOf());
+
+	m_deviceContext->RSSetState(m_skyRasterizerState.Get());
+	m_deviceContext->RSSetViewports(1, &m_RenderViewport); // 뷰포트 되돌리기
+
+	m_deviceContext->PSSetShader(m_skyboxPS.Get(), nullptr, 0);
+	m_deviceContext->PSSetShaderResources(5, 1, m_skyboxTexture.GetAddressOf());
+	m_deviceContext->PSSetSamplers(0, 1, m_samplerLinear.GetAddressOf());
+	m_deviceContext->PSSetConstantBuffers(0, 1, m_constantBuffer.GetAddressOf());
+
+	m_deviceContext->OMSetRenderTargets(1, m_backbufferRTV.GetAddressOf(), m_depthStencilView.Get());
+	m_deviceContext->OMSetDepthStencilState(m_skyDepthStencilState.Get(), 1); // 뎊스 스텐실 설정
+
+	m_deviceContext->UpdateSubresource(m_constantBuffer.Get(), 0, nullptr, &cb, 0, 0);
+
+	m_deviceContext->DrawIndexed(m_nSkyboxIndices, 0, 0);
+}
+
+void DeferredRenderApp::DepthOnlyPass()
+{
+	// 바인딩 해제
+	ID3D11ShaderResourceView* nullSRV[1] = { nullptr };
+	m_deviceContext->VSSetShaderResources(4, 1, nullSRV);
+	m_deviceContext->PSSetShaderResources(4, 1, nullSRV);
+
+	//상수 버퍼 갱신
+	ConstantBuffer cb;
+	cb.cameraView = XMMatrixTranspose(m_View);
+	cb.cameraProjection = XMMatrixTranspose(m_Projection);
+	cb.shadowView = XMMatrixTranspose(m_shadowView);
+	cb.shadowProjection = XMMatrixTranspose(m_shadowProj);
+
+	cb.ambient = m_LightAmbient;
+	cb.diffuse = m_LightDiffuse;
+	cb.specular = m_LightSpecular;
+
+	cb.shininess = m_Shininess;
+	cb.CameraPos = m_Camera.m_Position;
+
+	// 뷰포트 설정 + DSV 초기화, RS, OM 설정
+	D3D11_VIEWPORT viewport
+	{
+		m_shadowViewport.x, m_shadowViewport.y,
+		m_shadowViewport.width, m_shadowViewport.height,
+		m_shadowViewport.minDepth, m_shadowViewport.maxDepth
+	};
+	m_deviceContext->RSSetViewports(1, &viewport);
+	m_deviceContext->OMSetDepthStencilState(m_depthStencilStateWriteOn.Get(), 1);
+	m_deviceContext->OMSetRenderTargets(0, nullptr, m_shadowMapDSV.Get());
+	m_deviceContext->ClearDepthStencilView(m_shadowMapDSV.Get(), D3D11_CLEAR_DEPTH, 1.0f, 0);
+
+	// 렌더 파이프라인 설정
+	m_deviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	m_deviceContext->IASetInputLayout(m_inputLayout.Get());
+
+	m_deviceContext->UpdateSubresource(m_constantBuffer.Get(), 0, nullptr, &cb, 0, 0);
+	m_deviceContext->VSSetConstantBuffers(0, 1, m_constantBuffer.GetAddressOf());
+	m_deviceContext->PSSetSamplers(0, 1, m_samplerLinear.GetAddressOf());
+
+	m_deviceContext->VSSetShader(m_shadowMapVS.Get(), 0, 0);
+	// m_pDeviceContext->PSSetShader(NULL, NULL, 0); // 렌더 타겟에 기록할 RGBA가 없으므로 실행하지 않는다.
+	m_deviceContext->PSSetShader(m_shadowMapPS.Get(), NULL, 0); // 
+
+	// 모델 draw 호출
+	m_ground->Draw(m_deviceContext, m_materialBuffer);
+	m_chara->Draw(m_deviceContext, m_materialBuffer);
+	m_tree->Draw(m_deviceContext, m_materialBuffer);
+	m_sphere->Draw(m_deviceContext, m_materialBuffer);
+
+	for (auto& e : m_models)
+	{
+		if (!e->isRemoved) e->Draw(m_deviceContext, m_materialBuffer);
+	}
+}
+
+bool DeferredRenderApp::InitImGUI()
+{
+	bool isSetupSuccess = false;
+
+	// Setup Dear ImGui context 
+	IMGUI_CHECKVERSION();
+	ImGui::CreateContext();
+	ImGuiIO& io = ImGui::GetIO(); (void)io;
+	io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
+	io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
+
+	// Setup Dear ImGui style
+	ImGui::StyleColorsDark();
+
+	// Setup Platform/Renderer backends
+	isSetupSuccess = ImGui_ImplWin32_Init(m_hWnd);
+	if (!isSetupSuccess) return false;
+
+	isSetupSuccess = ImGui_ImplDX11_Init(m_device.Get(), m_deviceContext.Get());
+	if (!isSetupSuccess) return false;
+
+	return true;
+}
+
+void DeferredRenderApp::RenderImGUI()
+{
+	// Start the Dear ImGui frame
+	ImGui_ImplDX11_NewFrame();
+	ImGui_ImplWin32_NewFrame();
+	ImGui::NewFrame();
+
+	ImGui::SetNextWindowPos(ImVec2(800, 10), ImGuiCond_Once);
+	ImGui::SetNextWindowSize(ImVec2(200, 200), ImGuiCond_Once);
+
+	if (m_chara->modelAsset->animations.size() > 0)
+	{
+		ImGui::Begin("Middle Model Animation info");
+		{
+			ImGui::Text(std::to_string(m_chara->m_progressAnimationTime).c_str());
+			ImGui::Checkbox("isPlay", &m_chara->isAnimPlay);
+			ImGui::SliderFloat("Animation Duration", &m_chara->m_progressAnimationTime, 0.0f, m_chara->modelAsset->animations[m_chara->m_animationIndex].m_duration);
+		}
+		ImGui::End();
+	}
+
+	ImGui::Begin("ShadowMap");
+	{
+		ImTextureID img = (ImTextureID)(intptr_t)(m_shadowMapSRV.Get());
+		ImGui::Image(img, ImVec2(256, 256));
+		ImGui::DragFloat("m_shadowForwardDistFromCamera", &m_shadowForwardDistFromCamera);
+		ImGui::DragFloat3("m_shadowUpDistFromLookAt", &m_shadowUpDistFromLookAt.x);
+
+		ImGui::DragFloat("m_shadowNear", &m_shadowNear);
+		ImGui::DragFloat("m_shadowFar", &m_shadowFar);
+
+		if (m_shadowNear <= m_shadowMinNear) m_shadowNear = m_shadowMinNear;
+		if (m_shadowFar <= m_shadowMinFar) m_shadowFar = m_shadowMinFar;
+
+		ImGui::DragFloat("m_shadowFrustumAngle", &m_shadowFrustumAngle, 0.02f);
+
+		// m_shadow 관련 갱신
+		m_shadowProj = XMMatrixPerspectiveFovLH(m_shadowFrustumAngle, m_shadowViewport.width / (FLOAT)m_shadowViewport.height, m_shadowNear, m_shadowFar);
+		m_shadowLookAt = m_Camera.m_Position + m_Camera.GetForward() * m_shadowForwardDistFromCamera;	// 바라보는 방향 = 카메라 위치 + 카메라 바라보는 방향으로부터 떨어진 태양의 위치
+		m_shadowPos = m_Camera.m_Position + ((Vector3)-m_LightDirection * m_shadowUpDistFromLookAt);	// 위치
+		m_shadowView = XMMatrixLookAtLH(m_shadowPos, m_shadowLookAt, Vector3(0.0f, 1.0f, 0.0f));
+	}
+	ImGui::End();
+
+
+	// 월드 오브젝트 조종 창 만들기
+	ImGui::SetNextWindowPos(ImVec2(10, 10), ImGuiCond_Once);		// 처음 실행될 때 위치 초기화
+	ImGui::SetNextWindowSize(ImVec2(350, 500), ImGuiCond_Once);		// 처음 실행될 때 창 크기 초기화
+	ImGui::Begin("World Controller");
+
+	{
+		ImGui::DragFloat3("Middle Object Position", &m_charaPosition.x);
+
+		Vector3 cube1Rotation;
+		cube1Rotation.x = XMConvertToDegrees(m_charaRotation.x);
+		cube1Rotation.y = XMConvertToDegrees(m_charaRotation.y);
+		cube1Rotation.z = XMConvertToDegrees(m_charaRotation.z);
+		ImGui::DragFloat3("Middle Object Rotation", &cube1Rotation.x);
+		m_charaRotation.x = XMConvertToRadians(cube1Rotation.x);
+		m_charaRotation.y = XMConvertToRadians(cube1Rotation.y);
+		m_charaRotation.z = XMConvertToRadians(cube1Rotation.z);
+
+		ImGui::DragFloat("Middle Object Scale", &m_charaScale.x, 0.05f);
+		m_charaScale.y = m_charaScale.x;
+		m_charaScale.z = m_charaScale.x;
+
+		m_chara->m_Position = m_charaPosition;
+		m_chara->m_Rotation = m_charaRotation;
+		m_chara->m_Scale = m_charaScale;
+	}
+
+	ImGui::ColorEdit3("Light Color", &m_LightColor.x);
+	ImGui::NewLine();
+
+	// 카메라 위치 및 회전 설정
+	ImGui::DragFloat3("Camera Position", &m_Camera.m_Position.x);
+	ImGui::DragFloat3("Camera Rotation", &m_CameraRotation.x);
+
+	if (ImGui::Button("Set Rotation"))
+	{
+		m_Camera.m_Rotation.x = XMConvertToRadians(m_CameraRotation.x);
+		m_Camera.m_Rotation.y = XMConvertToRadians(m_CameraRotation.y);
+		m_Camera.m_Rotation.z = XMConvertToRadians(m_CameraRotation.z);
+	}
+
+	ImGui::NewLine();
+
+	// Near 값 설정
+	ImGui::DragFloat("Near", &m_Near, 0.5f);
+
+	// Far 값 설정
+	ImGui::DragFloat("Far", &m_Far, 0.5f);
+
+	// Fov 값 설정
+	ImGui::DragFloat("Fov Angle", &m_PovAngle, 0.02f);
+
+	if (m_Near <= 0.0f) m_Near = 0.01f;
+	if (m_Far <= m_Near) m_Far = 0.2f;
+
+	ImGui::NewLine();
+
+	ImGui::Text("Select tex:");
+	ImGui::Checkbox("Enable hasDiffuse", &useBaseColor);
+	ImGui::Checkbox("Enable hasNormal", &useNormal);
+	ImGui::Checkbox("Enable hasMatalness", &useMetalness);
+	ImGui::Checkbox("Enable hasRoughness", &useRoughness);
+
+	for (auto& mesh : m_chara->modelAsset->meshes)
+	{
+		mesh.GetMaterial().hasDiffuse = useBaseColor;
+		mesh.GetMaterial().hasNormal = useNormal;
+		mesh.GetMaterial().hasMatalness = useMetalness;
+		mesh.GetMaterial().hasRoughness = useRoughness;
+	}
+
+	ImGui::NewLine();
+
+	m_Projection = XMMatrixPerspectiveFovLH(m_PovAngle, m_ClientWidth / (FLOAT)m_ClientHeight, m_Near, m_Far);
+
+	ImGui::DragFloat3("Light Direction", &m_LightDirection.x, 0.1f, -1.0f, 1.0f);
+
+	ImGui::DragFloat("Roughness", &roughness, 0.01f, 0, 1);
+	ImGui::DragFloat("Metalness", &metalness, 0.01f, 0, 1);
+	ImGui::DragFloat("Lightintensity", &lightIntensity, 0.01f, 0, 1);
+	ImGui::ColorEdit3("BaseColor", &BaseColor.x);
+
+	ImGui::Spacing();
+
+	// 리셋 버튼
+	if (ImGui::Button("Reset", { 50, 20 }))
+	{
+		ResetValues();
+	}
+
+	ImGui::End();
+
+	ImGui::Begin("Deferred Info");
+	{
+		static const char* GBufferNames[] =
+		{
+			"BaseColor",
+			"Normal",
+			"WorldPos",
+			"Metal",
+			"Rough",
+			"Specular",
+			"Emission"
+		};
+
+		int size = static_cast<int>(EGbuffer::Count);
+
+		for (int i = 0; i < size; i++)
+		{
+			// 카드 하나 시작
+			ImGui::BeginGroup();
+
+			// 카드 박스 (Child)
+			ImGui::BeginChild(
+				GBufferNames[i],
+				ImVec2(150, 170),   // 카드 크기 (텍스처 + 여백)
+				true,               // 테두리 표시
+				ImGuiWindowFlags_NoScrollbar
+			);
+
+			// 텍스처 이름
+			ImGui::Text("%s", GBufferNames[i]);
+			ImGui::Separator();
+
+			// 이미지 출력
+			ImTextureID img = (ImTextureID)(intptr_t)(m_gBufferSRV[i].Get());
+			ImGui::Image(img, ImVec2(128, 128));
+
+			ImGui::EndChild();
+			ImGui::EndGroup();
+
+			// 2개씩 배치
+			if (i % 2 == 0)
+				ImGui::SameLine();
+		}
+	}
+	ImGui::End();
+
+	// rendering
+	ImGui::Render();
+	ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+}
+
+void DeferredRenderApp::UninitImGUI()
+{
+	// Cleanup
+	ImGui_ImplDX11_Shutdown();
+	ImGui_ImplWin32_Shutdown();
+	ImGui::DestroyContext();
+}
+
+bool DeferredRenderApp::InitD3D()
+{
+	HRESULT hr = S_OK;
+
+	// 1. D3D11 Device, DeviceContext 생성
+	UINT creationFlag = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+
+#ifdef _DEBUG
+	creationFlag |= D3D11_CREATE_DEVICE_DEBUG;
+#endif //  _DEBUG
+
+	// 그래픽 카드 하드웨어의 스펙으로 호환되는 가장 높은 DirectX 기능레벨로 생성하여 드라이버가 작동한다.
+	// 인터페이스는 Direct3D11이지만 GPU 드라이버는 D3D12 드라이버가 작동될 수 있다.
+	D3D_FEATURE_LEVEL featureLevels[] =
+	{	// 0번 index부터 순서대로 시도
+		D3D_FEATURE_LEVEL_12_2,D3D_FEATURE_LEVEL_12_1,D3D_FEATURE_LEVEL_12_0,D3D_FEATURE_LEVEL_11_1,D3D_FEATURE_LEVEL_11_0
+	};
+	D3D_FEATURE_LEVEL actualFeatureLevel;	// 최종 feature level 저장 변수
+
+	HR_T(D3D11CreateDevice
+	(
+		nullptr,
+		D3D_DRIVER_TYPE_HARDWARE,
+		0,
+		creationFlag,
+		featureLevels,
+		ARRAYSIZE(featureLevels),
+		D3D11_SDK_VERSION,
+		&m_device,
+		&actualFeatureLevel,
+		&m_deviceContext
+	));
+
+#if !USE_FLIPMODE
+	m_pDeviceContext->OMSetRenderTargets(1, m_pRenderTargetView.GetAddressOf(), nullptr);
+#endif
+
+	// 4. viewport 설정
+	m_RenderViewport = {};
+	m_RenderViewport.TopLeftX = 0;
+	m_RenderViewport.TopLeftY = 0;
+	m_RenderViewport.Width = (float)m_ClientWidth;
+	m_RenderViewport.Height = (float)m_ClientHeight;
+	m_RenderViewport.MinDepth = 0.0f;
+	m_RenderViewport.MaxDepth = 1.0f;
+	m_deviceContext->RSSetViewports(1, &m_RenderViewport);
+
+	// 5. 뎊스 스텐실 뷰 설정
+	D3D11_TEXTURE2D_DESC descDepth = {};
+	descDepth.Width = m_ClientWidth;
+	descDepth.Height = m_ClientHeight;
+	descDepth.MipLevels = 1;
+	descDepth.ArraySize = 1;
+	descDepth.Format = DXGI_FORMAT_D24_UNORM_S8_UINT; // https://learn.microsoft.com/ko-kr/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format
+	descDepth.SampleDesc.Count = 1;
+	descDepth.SampleDesc.Quality = 0;
+	descDepth.Usage = D3D11_USAGE_DEFAULT;
+	descDepth.BindFlags = D3D11_BIND_DEPTH_STENCIL;
+	descDepth.CPUAccessFlags = 0;
+	descDepth.MiscFlags = 0;
+
+	// 뎊스 스탠실 상태 설정
+	D3D11_DEPTH_STENCIL_DESC depthStencilDesc = {};
+	depthStencilDesc.DepthEnable = FALSE;                // 깊이 테스트 활성화
+	depthStencilDesc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ZERO; // 깊이 버퍼 업데이트 허용
+	depthStencilDesc.DepthFunc = D3D11_COMPARISON_LESS; // 작은 Z 값이 앞에 배치되도록 설정
+	depthStencilDesc.StencilEnable = FALSE;            // 스텐실 테스트 비활성화
+
+	m_device->CreateDepthStencilState(&depthStencilDesc, &m_depthStencilStateWriteOff);
+
+	depthStencilDesc = {};
+	depthStencilDesc.DepthEnable = TRUE;                // 깊이 테스트 활성화
+	depthStencilDesc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ALL; // 깊이 버퍼 업데이트 허용
+	depthStencilDesc.DepthFunc = D3D11_COMPARISON_LESS; // 작은 Z 값이 앞에 배치되도록 설정
+	depthStencilDesc.StencilEnable = FALSE;            // 스텐실 테스트 비활성화
+
+	m_device->CreateDepthStencilState(&depthStencilDesc, &m_depthStencilStateWriteOn);
+
+	// create depthStencil texture
+	ComPtr<ID3D11Texture2D> pTextureDepthStencil;
+	HR_T(m_device->CreateTexture2D(&descDepth, nullptr, pTextureDepthStencil.GetAddressOf()));
+
+	// create the depth stencil view
+	D3D11_DEPTH_STENCIL_VIEW_DESC descDSV = {};
+	descDSV.Format = descDepth.Format;
+	descDSV.ViewDimension = D3D11_DSV_DIMENSION_TEXTURE2D; // 사용되는 리소스 엑세스 방식 설정 : https://learn.microsoft.com/ko-kr/windows/win32/api/d3d11/ne-d3d11-d3d11_dsv_dimension 
+	descDSV.Texture2D.MipSlice = 0;
+	HR_T(m_device->CreateDepthStencilView(pTextureDepthStencil.Get(), &descDSV, m_depthStencilView.GetAddressOf()));
+
+	// create blending state https://learn.microsoft.com/ko-kr/windows/win32/api/d3d11/ns-d3d11-d3d11_blend_desc
+	// Color = SrcAlpha * SrcColor + (1 - SrcAlpha) * DestColor 
+	// Alpha = SrcAlpha
+	D3D11_BLEND_DESC blendDesc = {};
+	blendDesc.RenderTarget[0].BlendEnable			= TRUE;						
+	blendDesc.RenderTarget[0].SrcBlend = D3D11_BLEND_ONE;
+	blendDesc.RenderTarget[0].DestBlend = D3D11_BLEND_ONE;
+	blendDesc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;
+	blendDesc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
+	blendDesc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ONE;
+	blendDesc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
+	blendDesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+
+	m_device->CreateBlendState(&blendDesc, m_additiveBlendState.GetAddressOf());
+
+	// material buffer
+	D3D11_BUFFER_DESC mbd = {};
+	mbd.Usage = D3D11_USAGE_DEFAULT;
+	mbd.ByteWidth = sizeof(Material);
+	mbd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+	mbd.CPUAccessFlags = 0;
+	HR_T(m_device->CreateBuffer(&mbd, nullptr, m_materialBuffer.GetAddressOf()));
+
+	return true;
+}
+
+bool DeferredRenderApp::InitScene()
+{
+	HRESULT hr = S_OK;
+
+	// 6. Render() 에서 파이프라인에 바인딩할 상수 버퍼 생성
+	D3D11_BUFFER_DESC bufferDesc = {};
+	bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+	bufferDesc.ByteWidth = sizeof(ConstantBuffer);
+	bufferDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+	bufferDesc.CPUAccessFlags = 0;
+	HR_T(m_device->CreateBuffer(&bufferDesc, nullptr, m_constantBuffer.GetAddressOf()));
+
+	bufferDesc = {};
+	bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+	bufferDesc.ByteWidth = sizeof(LightDirectionCB);
+	bufferDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+	bufferDesc.CPUAccessFlags = 0;
+	HR_T(m_device->CreateBuffer(&bufferDesc, nullptr, m_lightDirectionBuffer.GetAddressOf()));
+
+	// 쉐이더에 상수버퍼에 전달할 시스템 메모리 데이터 초기화
+	m_World = XMMatrixIdentity();
+
+	XMVECTOR Eye = XMVectorSet(0.0f, 10.0f, -8.0f, 0.0f);
+	XMVECTOR At = XMVectorSet(0.0f, 0.0f, 0.0f, 0.0f);
+	XMVECTOR Up = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
+	m_View = XMMatrixLookAtLH(Eye, At, Up);
+	m_Projection = XMMatrixPerspectiveFovLH(m_PovAngle, m_ClientWidth / (FLOAT)m_ClientHeight, m_Near, m_Far);
+
+	// 샘플링 상태 설정
+	D3D11_SAMPLER_DESC sampDesc = {};
+	sampDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;	// 텍스처 샘플링할 때 사용할 필터링 방법
+	sampDesc.AddressU = D3D11_TEXTURE_ADDRESS_WRAP;		// 범위 밖에 있는 텍스처 좌표 확인 방법
+	sampDesc.AddressV = D3D11_TEXTURE_ADDRESS_WRAP;
+	sampDesc.AddressW = D3D11_TEXTURE_ADDRESS_WRAP;
+	sampDesc.ComparisonFunc = D3D11_COMPARISON_NEVER;	// 샘플링된 데이터를 기존 데이터와 확인하는 방법
+	sampDesc.MinLOD = 0;
+	sampDesc.MaxLOD = D3D11_FLOAT32_MAX;
+	HR_T(m_device->CreateSamplerState(&sampDesc, m_samplerLinear.GetAddressOf()));
+
+	sampDesc = {};
+	sampDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+	sampDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+	sampDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+	sampDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+	sampDesc.MipLODBias = 0.0f;
+	sampDesc.MaxAnisotropy = 1;
+	sampDesc.ComparisonFunc = D3D11_COMPARISON_ALWAYS;
+	sampDesc.BorderColor[0] = sampDesc.BorderColor[1] = sampDesc.BorderColor[2] = sampDesc.BorderColor[3] = 0.0f;
+	sampDesc.MinLOD = 0.0f;
+	sampDesc.MaxLOD = D3D11_FLOAT32_MAX;
+	HR_T(m_device->CreateSamplerState(&sampDesc, m_samplerPoint.GetAddressOf()));
+
+	// 래스터라이저
+	D3D11_RASTERIZER_DESC rasterizerDesc = {};
+	rasterizerDesc.CullMode = D3D11_CULL_FRONT;
+	rasterizerDesc.FillMode = D3D11_FILL_SOLID;
+	rasterizerDesc.DepthClipEnable = true;
+	rasterizerDesc.FrontCounterClockwise = true;
+
+	m_device->CreateRasterizerState(&rasterizerDesc, &m_rasterizerState);
+
+	rasterizerDesc = {};
+	rasterizerDesc.CullMode = D3D11_CULL_FRONT;
+	rasterizerDesc.FillMode = D3D11_FILL_SOLID;
+	rasterizerDesc.DepthClipEnable = true;
+	rasterizerDesc.FrontCounterClockwise = true;
+
+	m_device->CreateRasterizerState(&rasterizerDesc, &m_transparentRasterizerState);
+
+	// 모델들이 사용할 버퍼 만들기
+	// 트랜스폼 상수 버퍼 만들기
+	bufferDesc = {};
+	bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+	bufferDesc.ByteWidth = sizeof(TransformBuffer);
+	bufferDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+	bufferDesc.CPUAccessFlags = 0;
+	HR_T(m_device->CreateBuffer(&bufferDesc, nullptr, m_transformBuffer.GetAddressOf()));
+
+	// 본 포즈 버퍼 만들기
+	bufferDesc = {};
+	bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+	bufferDesc.ByteWidth = sizeof(BonePoseBuffer);
+	bufferDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+	bufferDesc.CPUAccessFlags = 0;
+	HR_T(m_device->CreateBuffer(&bufferDesc, nullptr, m_bonePoseBuffer.GetAddressOf()));
+
+	// 본 오프셋 버퍼 만들기
+	bufferDesc = {};
+	bufferDesc.Usage = D3D11_USAGE_DEFAULT;
+	bufferDesc.ByteWidth = sizeof(BoneOffsetBuffer);
+	bufferDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+	bufferDesc.CPUAccessFlags = 0;
+	HR_T(m_device->CreateBuffer(&bufferDesc, nullptr, m_boneOffsetBuffer.GetAddressOf()));
+
+	// 모델 생성
+	m_chara = make_unique<SkeletalModel>();
+	if (!m_chara->Load(m_hWnd, m_device, m_deviceContext, "..\\Resource\\char.fbx"))
+	{
+		MessageBox(m_hWnd, L"FBX file is invaild at path", NULL, MB_ICONERROR | MB_OK);
+	}
+	m_chara->GetBuffer(m_transformBuffer, m_bonePoseBuffer, m_boneOffsetBuffer);
+	m_chara->m_Position = { 0, 100, 0 };
+
+	m_ground = make_unique<SkeletalModel>();
+	if (!m_ground->Load(m_hWnd, m_device, m_deviceContext, "..\\Resource\\Ground.fbx"))
+	{
+		MessageBox(m_hWnd, L"FBX file is invaild at path", NULL, MB_ICONERROR | MB_OK);
+	}
+	m_ground->GetBuffer(m_transformBuffer, m_bonePoseBuffer, m_boneOffsetBuffer);
+	m_ground->m_Position = { 0, -100, 0 };
+
+	m_tree = make_unique<SkeletalModel>();
+	if (!m_tree->Load(m_hWnd, m_device, m_deviceContext, "..\\Resource\\Tree.fbx"))
+	{
+		MessageBox(m_hWnd, L"FBX file is invaild at path", NULL, MB_ICONERROR | MB_OK);
+	}
+	m_tree->GetBuffer(m_transformBuffer, m_bonePoseBuffer, m_boneOffsetBuffer);
+	m_tree->m_Scale = { 100, 100, 100 };
+	m_tree->m_Position = { 0, 0, 300 };
+
+	m_sphere = make_unique<SkeletalModel>();
+	if (!m_sphere->Load(m_hWnd, m_device, m_deviceContext, "..\\Resource\\sphere.fbx"))
+	{
+		MessageBox(m_hWnd, L"FBX file is invaild at path", NULL, MB_ICONERROR | MB_OK);
+	}
+	m_sphere->GetBuffer(m_transformBuffer, m_bonePoseBuffer, m_boneOffsetBuffer);
+	m_sphere->m_Position = { 200, 100, 100 };
+
+	HR_T(CreateDDSTextureFromFile(m_device.Get(), L"..\\Resource\\skyboxEnvHDR.dds", nullptr, m_skyboxTexture.GetAddressOf()));
+	HR_T(CreateDDSTextureFromFile(m_device.Get(), L"..\\Resource\\skyboxDiffuseHDR.dds", nullptr, m_IBLIrradiance.GetAddressOf()));
+	HR_T(CreateDDSTextureFromFile(m_device.Get(), L"..\\Resource\\skyboxSpecularHDR.dds", nullptr, m_IBLSpecular.GetAddressOf()));
+	HR_T(CreateDDSTextureFromFile(m_device.Get(), L"..\\Resource\\skyboxBrdf.dds", nullptr, m_IBLLookUpTable.GetAddressOf()));
+
+	return true;
+}
+
+bool DeferredRenderApp::InitEffect()
+{
+	// Geometry Pass
+	D3D11_INPUT_ELEMENT_DESC layout[] =
+	{
+		{ "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+		{ "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+		{ "TANGENT", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+		{ "BINORMAL", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+		{ "NORMAL", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+		{ "BLENDINDICES", 0, DXGI_FORMAT_R32G32B32A32_SINT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+		{ "BLENDWEIGHTS", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 }
+	};
+
+	ComPtr<ID3DBlob> vertexShaderBuffer = nullptr;
+	HR_T(CompileShaderFromFile(L"Shaders\\VS_GBuffer.hlsl", "main", "vs_5_0", vertexShaderBuffer.GetAddressOf()));
+	HR_T(m_device->CreateInputLayout(layout, ARRAYSIZE(layout), vertexShaderBuffer->GetBufferPointer(), vertexShaderBuffer->GetBufferSize(), m_inputLayout.GetAddressOf()));
+
+	HR_T(m_device->CreateVertexShader(vertexShaderBuffer->GetBufferPointer(), vertexShaderBuffer->GetBufferSize(), NULL, m_skinnedMeshVertexShader.GetAddressOf()));
+
+	vertexShaderBuffer.Reset();
+	HR_T(CompileShaderFromFile(L"Shaders\\VS_DepthOnlyPass.hlsl", "main", "vs_5_0", vertexShaderBuffer.GetAddressOf()));
+	HR_T(m_device->CreateVertexShader(vertexShaderBuffer->GetBufferPointer(), vertexShaderBuffer->GetBufferSize(), NULL, m_shadowMapVS.GetAddressOf()));
+
+	// Light Pass
+	// ....
+
+	// Ps
+	ComPtr<ID3DBlob> pixelShaderBuffer = nullptr;
+	pixelShaderBuffer.Reset();
+	HR_T(CompileShaderFromFile(L"Shaders\\PS_DepthOnlyPass.hlsl", "main", "ps_5_0", pixelShaderBuffer.GetAddressOf()));
+	HR_T(m_device->CreatePixelShader(pixelShaderBuffer->GetBufferPointer(), pixelShaderBuffer->GetBufferSize(), NULL, m_shadowMapPS.GetAddressOf()));
+
+	pixelShaderBuffer.Reset();
+	HR_T(CompileShaderFromFile(L"Shaders\\PS_Gbuffer.hlsl", "main", "ps_5_0", pixelShaderBuffer.GetAddressOf()));
+	HR_T(m_device->CreatePixelShader(pixelShaderBuffer->GetBufferPointer(), pixelShaderBuffer->GetBufferSize(), NULL, m_PBRPS.GetAddressOf()));
+
+	pixelShaderBuffer.Reset();
+	HR_T(CompileShaderFromFile(L"Shaders\\PS_DirectionalLight.hlsl", "main", "ps_5_0", pixelShaderBuffer.GetAddressOf()));
+	HR_T(m_device->CreatePixelShader(pixelShaderBuffer->GetBufferPointer(), pixelShaderBuffer->GetBufferSize(), NULL, m_directionalLightPS.GetAddressOf()));
+
+	return true;
+}
+
+void DeferredRenderApp::ResetValues()
+{
+	m_Near = 0.01f;
+	m_Far = 3000.0f;
+	m_PovAngle = XM_PIDIV2;
+
+	m_CameraRotation = Vector3::Zero;
+	m_Camera.SetRotation(m_CameraRotation);
+	m_Camera.SetPosition(m_CameraPositionInitial);
+
+	m_Projection = XMMatrixPerspectiveFovLH(m_PovAngle, m_ClientWidth / (FLOAT)m_ClientHeight, m_Near, m_Far);
+
+	m_LightDirection = m_LightDirectionInitial;
+}
+
+void DeferredRenderApp::ShowMatrix(const DirectX::XMFLOAT4X4& mat, const char* label)
+{
+	// 각 행을 출력
+	ImGui::Text("%.3f  %.3f  %.3f  %.3f", mat._11, mat._12, mat._13, mat._14);
+	ImGui::Text("%.3f  %.3f  %.3f  %.3f", mat._21, mat._22, mat._23, mat._24);
+	ImGui::Text("%.3f  %.3f  %.3f  %.3f", mat._31, mat._32, mat._33, mat._34);
+	ImGui::Text("%.3f  %.3f  %.3f  %.3f", mat._41, mat._42, mat._43, mat._44);
+}
+
+// Forward declare message handler from imgui_impl_win32.cpp
+extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+LRESULT DeferredRenderApp::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+	if (ImGui_ImplWin32_WndProcHandler(hWnd, message, wParam, lParam))
+		return true;
+
+	//switch (message)
+	//{
+	//case WM_ENTERSIZEMOVE:
+	//	screenIsSizeMove = true;
+	//	break;
+	//case WM_EXITSIZEMOVE:
+	//	screenIsSizeMove = false;
+	//	if (m_pInstance)
+	//	{
+	//		RECT rc;
+	//		GetClientRect(hWnd, &rc);
+	//		ResizeScreen(rc.right - rc.left, rc.bottom - rc.top);
+	//	}
+	//	break;
+	//default:
+	//	break;
+	//}
+
+	return __super::WndProc(hWnd, message, wParam, lParam);
+}
+
+void DeferredRenderApp::OnInputProcess(const Keyboard::State& KeyState, const Keyboard::KeyboardStateTracker& KeyTracker, const Mouse::State& MouseState, const Mouse::ButtonStateTracker& MouseTracker)
+{
+	__super::OnInputProcess(KeyState, KeyTracker, MouseState, MouseTracker);
+
+	if(KeyState.O)
+	{
+		auto model = make_unique<SkeletalModel>();
+		if (!model->Load(m_hWnd, m_device, m_deviceContext, "..\\Resource\\SillyDancing.fbx"))
+		{
+			MessageBox(m_hWnd, L"FBX file is invaild at path", NULL, MB_ICONERROR | MB_OK);
+		}
+
+		model->GetBuffer(m_transformBuffer, m_bonePoseBuffer, m_boneOffsetBuffer);
+
+		Vector3 pos = m_Camera.m_Position;
+		model->m_Position = pos;
+		m_models.push_back(std::move(model));
+	}
+
+	if (KeyState.P)
+	{
+		if (!m_models.empty())
+		{
+			m_models.front()->isRemoved = true;
+			m_models.pop_front();
+		}
+	}
+
+	if (KeyState.Delete)
+	{
+		for (auto& e : m_models)
+		{
+			e->isRemoved = true;
+		}
+
+		m_models.clear();
+	}
+}

--- a/D3D11_1/21_ResizeScreen/DeferredRenderApp.h
+++ b/D3D11_1/21_ResizeScreen/DeferredRenderApp.h
@@ -209,9 +209,9 @@ public:
 	void CreateGbuffers();
 
 	// screen resize
-	//bool screenIsSizeMove = false;
-	//void ResizeScreen(int width, int height); // 스크린 리사이즈 이벤트시 호출
-	//void ResizeResource();
+	// bool screenIsSizeMove = false;
+	// void ResizeScreen(int width, int height); // 스크린 리사이즈 이벤트시 호출
+	// void ResizeResource();
 
 
 	// =============================================================

--- a/D3D11_1/21_ResizeScreen/DeferredRenderApp.h
+++ b/D3D11_1/21_ResizeScreen/DeferredRenderApp.h
@@ -1,0 +1,251 @@
+#pragma once
+#include "SkeletalModel.h"
+
+// DirectX11 
+#include <d3d11.h>
+#include <dxgi1_2.h>
+#include <wrl/client.h>
+
+// DirectXTK
+#include <directxtk/SimpleMath.h>
+#include <directxtk/CommonStates.h> // https://github.com/microsoft/DirectXTK/wiki/CommonStates
+#include <directxtk/Effects.h>		// https://github.com/microsoft/DirectXTK/wiki/BasicEffect
+
+// imgui
+#include "imgui_impl_dx11.h"
+#include "imgui_impl_win32.h"
+#include "imgui.h"
+
+// other files
+#include "../Common/GameApp.h"
+#include "DebugDraw.h"
+#include <deque>
+
+using namespace DirectX::SimpleMath;
+using namespace Microsoft::WRL;
+
+class DeferredRenderApp : public GameApp
+{
+public:
+	DeferredRenderApp(HINSTANCE hInstance);
+	~DeferredRenderApp();
+
+	// Model
+	unique_ptr<SkeletalModel> m_chara = nullptr;	
+	unique_ptr<SkeletalModel> m_ground = nullptr;	 
+	unique_ptr<SkeletalModel> m_tree = nullptr;	 
+	unique_ptr<SkeletalModel> m_sphere = nullptr;	 
+	deque<unique_ptr<SkeletalModel>> m_models;
+
+	// 렌더링 파이프라인을 구성하는 필수 객체 인터페이스
+	ComPtr<ID3D11PixelShader>		m_pixelShader = nullptr;				// 사용할 픽셀 셰이더
+	ComPtr<ID3D11Device>			m_device = nullptr;						// 디바이스
+	ComPtr<ID3D11DeviceContext>		m_deviceContext = nullptr;			// 디바이스 컨텍스트
+	ComPtr<IDXGISwapChain1>			m_swapChain = nullptr;					// 스왑체인 
+	ComPtr<ID3D11RenderTargetView>	m_backbufferRTV = nullptr;	// 랜더 타겟
+	ComPtr<ID3D11DepthStencilView>	m_depthStencilView = nullptr;	// 깊이 값 처리를 위한 뎊스스텐실 뷰
+	ComPtr<ID3D11DepthStencilState> m_depthStencilStateWriteOn = nullptr;
+	ComPtr<ID3D11DepthStencilState> m_depthStencilStateWriteOff = nullptr;
+	ComPtr<ID3D11RasterizerState>	m_rasterizerState = nullptr;
+	ComPtr<ID3D11RasterizerState>	m_transparentRasterizerState = nullptr;
+
+	// vertex shaderes
+	ComPtr<ID3D11VertexShader> m_rigidMeshVertexShader = nullptr;
+	ComPtr<ID3D11VertexShader> m_skinnedMeshVertexShader = nullptr;
+
+
+	// 렌더링 파이프라인에 적용하는 객체와 정보
+	ComPtr<ID3D11InputLayout> m_inputLayout = nullptr;			// 입력 레이아웃
+	ComPtr<ID3D11Buffer> m_constantBuffer = nullptr;			// 상수 버퍼
+	ComPtr<ID3D11Buffer> m_materialBuffer{};					// 재질 버퍼
+
+	// 리소스 객체
+	ComPtr<ID3D11SamplerState> m_samplerLinear;	// 샘플링 객체
+
+	// 좌표계 변환을 위한 행렬 모음
+	Matrix m_World;				// 월드 좌표계 공간으로 변환을 위한 행렬, origin 위치에 있는 큐브 행렬
+	Matrix m_View;				// 뷰 좌표계 공간으로 변환을 위한 행렬.
+	Matrix m_Projection;		// 단위 장치 좌표계 ( Normalized Device Coordinate) 공간으로 변환을 위한 행렬.
+
+	Vector4 m_LightDirection{};				// Directional Light의 방향
+	Color m_LightColor{ 1,1,1,1 };			// Directional Light의 색
+
+	// imgui 컨트롤 변수
+	Vector3 m_charaPosition{};
+	Vector3 m_charaRotation{};
+	Vector3 m_charaScale{ 1.0f,1.0f,1.0f };
+
+	// 카메라
+	Vector3 m_CameraPositionInitial{ 0.0f, 100.0f, -200.0f };
+	Vector3 m_CameraRotation{};
+
+	// 빛
+	Vector4 m_LightDirectionInitial{ 0.0f, -1.0f, 0.0f, 1.0f };
+	Vector4 m_LightAmbient{ 0.1f, 0.1f, 0.1f, 0.1f }; // 환경광 반사 계수
+	Vector4 m_LightDiffuse{ 0.9f, 0.9f, 0.9f, 1.0f }; // 난반사 계수
+	Vector4 m_LightSpecular{ 0.9f, 0.9f, 0.9f, 1.0f }; // 정반사 계수
+	FLOAT m_Shininess = 40.0f; // 광택 지수
+
+	float m_Near = 0.01f;
+	float m_Far = 3000.0f;
+	float m_PovAngle = XM_PIDIV2;
+
+	// 그림자
+	ComPtr<ID3D11VertexShader> m_shadowMapVS;			//  shadowMap에 사용할 vs
+	ComPtr<ID3D11PixelShader> m_shadowMapPS = nullptr;
+
+	ComPtr<ID3D11Texture2D> m_shadowMap;				// 깊이 값을 기록할 텍스처
+	ComPtr<ID3D11DepthStencilView> m_shadowMapDSV;		// 깊이 값 기록을 설정할 객체
+	ComPtr<ID3D11ShaderResourceView> m_shadowMapSRV;	// 깊이 버퍼를 슬롯에서 설정하고 사용하기 위한 객체
+
+	Matrix m_shadowView{};
+	Matrix m_shadowProj{};
+	Vector3 m_shadowLookAt{};
+	Vector3 m_shadowPos{};
+	float m_shadowFrustumAngle = XM_PIDIV4;
+
+	Viewport m_shadowViewport = { 0, 0, 8192, 8192, 0.0f, 1.0f }; // x, y, width, height, min, max
+	D3D11_VIEWPORT m_RenderViewport = {};
+	float m_shadowForwardDistFromCamera = 1.0f;
+	float m_shadowNear = 400.0f;
+	float m_shadowFar = 3000.0f;
+	const float m_shadowMinNear = 400.0f;
+	const float m_shadowMinFar = 1001.0f;
+
+	// 그림자 디버그
+	ComPtr<ID3D11InputLayout> m_debugDrawInputLayout = nullptr; // debug inputlayout
+	unique_ptr<DirectX::CommonStates> m_states;	// CommonState : provide the stock? state objects
+	unique_ptr<PrimitiveBatch<VertexPositionColor>> m_batch; // vertexPositionColor : proivde input layout
+	unique_ptr<DirectX::BasicEffect> m_effect;	// BasicEffect : provide the vertex and pixel shader progrmas
+
+	Vector3 m_shadowUpDistFromLookAt{ 1000, 1000, 1000 };
+	Vector3 m_GroundScale{ 20,1,20 };
+
+	// model buffer
+	ComPtr<ID3D11Buffer> m_transformBuffer{};
+	ComPtr<ID3D11Buffer> m_bonePoseBuffer{};
+	ComPtr<ID3D11Buffer> m_boneOffsetBuffer{};
+
+	// dxgi들
+	ComPtr<IDXGIDevice3> dxgiDevice3{};
+	ComPtr<IDXGIFactory6> dxgiFactory6{};
+	ComPtr<IDXGIAdapter1> dxgiAdapter1{};
+	ComPtr<IDXGIAdapter3> dxgiAdapter3{};
+
+	// 스카이 박스
+	ComPtr<ID3D11ShaderResourceView> m_skyboxTexture;
+
+	ComPtr<ID3D11VertexShader> m_skyboxVS = nullptr;				// 스카이 박스용 정점 셰이더
+	ComPtr<ID3D11PixelShader> m_skyboxPS = nullptr;					// 스카이 박스용 픽셀 셰이더
+	ComPtr<ID3D11InputLayout> m_skyboxInputLayout = nullptr;		// 입력 레이아웃
+	ComPtr<ID3D11Buffer> m_skyboxVertexBuffer = nullptr;			// 스카이 박스 정점 버퍼
+	UINT m_SkyboxVertexBufferStride = 0;							// 스카이 박스 정점 하나의 버퍼 크기
+	UINT m_SkyboxVertexBufferOffset = 0;							// 스카이 박스 정점 버퍼의 오프셋
+	ComPtr<ID3D11Buffer> m_skyboxIndexBuffer;						// 스카이 박스가 사용할 인덱스 버퍼
+	int m_nSkyboxIndices = 0;										// 스카이박스 인덱스 버퍼 개수
+
+	ComPtr<ID3D11RasterizerState> m_skyRasterizerState = nullptr;	// 스카이박스 래스터라이저 상태
+	ComPtr<ID3D11DepthStencilState> m_skyDepthStencilState = nullptr;	// 스카이 박스를 위한 뎊스스텐실 상태 개체
+
+	// PBR
+	ComPtr<ID3D11PixelShader> m_PBRPS = nullptr;
+	float roughness = 0.1;
+	float metalness = 0.5;
+	float lightIntensity = 1.0f;
+
+	Color BaseColor{ 0,0,0,1 };
+	bool useBaseColor = true; // NOTE: 텍스처 없는 오브젝트는 강제로 플래그 활성화되서 출력이 안될 수 있음.
+	bool useNormal = true;
+	bool useMetalness = true;
+	bool useRoughness = true;
+
+	// PBR IBL
+	ComPtr<ID3D11ShaderResourceView> m_IBLIrradiance;
+	ComPtr<ID3D11ShaderResourceView> m_IBLSpecular;
+	ComPtr<ID3D11ShaderResourceView> m_IBLLookUpTable;
+
+	// Quad
+	DXGI_FORMAT m_HDRFormat = DXGI_FORMAT_R10G10B10A2_UNORM;
+	ComPtr<IDXGIFactory2> m_factory;
+
+	ComPtr<ID3D11InputLayout> m_quadInputLayout;
+	ComPtr<ID3D11VertexShader> m_quadVertexShader;
+	ComPtr<ID3D11Buffer> m_quadVertexBuffer;
+	ComPtr<ID3D11Buffer> m_quadIndexBuffer;
+	ComPtr<ID3D11Buffer> m_lightDirectionBuffer;
+
+	UINT m_quadVertexBufferStride;
+	UINT m_quadVertexBufferOffset;
+	UINT m_quadIndicesCount;
+
+	void CreateQuad();
+
+	// Deferred Rendering
+	enum class EGbuffer
+	{
+		BaseColor = 0,
+		Normal,
+		WorldPos,
+		Matal,
+		Rough,
+		Specular,
+		Emission,
+		Count
+	};
+
+	int gbufferCount = 0;
+
+	ComPtr<ID3D11SamplerState> m_samplerPoint{}; // ??
+
+	std::vector<ComPtr<ID3D11RenderTargetView>> m_gBufferRTV; 
+	std::vector<ComPtr<ID3D11ShaderResourceView>> m_gBufferSRV;
+	std::vector<ComPtr<ID3D11Texture2D>> m_gBufferTextures;
+
+	ComPtr<ID3D11BlendState> m_additiveBlendState{};
+
+	ComPtr<ID3D11VertexShader> m_directionalLightVS{};
+	ComPtr<ID3D11PixelShader> m_directionalLightPS{};
+
+	void CreateGbuffers();
+
+	// screen resize
+	//bool screenIsSizeMove = false;
+	//void ResizeScreen(int width, int height); // 스크린 리사이즈 이벤트시 호출
+	//void ResizeResource();
+
+
+	// =============================================================
+	virtual bool OnInitialize();
+	virtual void OnUpdate();
+	virtual void OnRender();
+
+	void DepthOnlyPass();				// 그림자 그리는 패스
+	void RenderPassGBuffer();			// 디퍼드 렌더링을 위한 Gbuffer 패스
+	void RenderPassDirectionalLight();	// directional light에 대해 추가하는 패스
+	void SkyboxPass();					// Skybox 그리는 패스
+
+
+	bool InitImGUI();
+	void RenderImGUI();
+	void UninitImGUI();
+
+	bool InitD3D();
+	bool InitScene();
+	bool InitEffect();
+	void InitDebugDraw();	// 디버그 관련 초기화 함수
+	void InitShdowMap();	// ShadowMap 관련 초기화 함수
+	bool InitDxgi();		// 메모리 사용량 디버그용 dxgi
+	bool InitSkyBox();
+	void CreateSwapchain();
+
+	void DrawFrustum(Matrix worldMat, Matrix viewMat, Matrix proejctionMat,
+		float angle, float AspectRatio, float nearZ, float farZ, XMVECTORF32 color = Colors::Red); // 절두체 그리는 함수
+
+	void ResetValues();
+	void ShowMatrix(const DirectX::XMFLOAT4X4& mat, const char* label = "Matrix");
+
+	virtual LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+
+	void OnInputProcess(const Keyboard::State& KeyState, const Keyboard::KeyboardStateTracker& KeyTracker,
+		const Mouse::State& MouseState, const Mouse::ButtonStateTracker& MouseTracker) override;
+};

--- a/D3D11_1/21_ResizeScreen/DeferredRenderApp.h
+++ b/D3D11_1/21_ResizeScreen/DeferredRenderApp.h
@@ -209,9 +209,9 @@ public:
 	void CreateGbuffers();
 
 	// screen resize
-	// bool screenIsSizeMove = false;
-	// void ResizeScreen(int width, int height); // 스크린 리사이즈 이벤트시 호출
-	// void ResizeResource();
+	bool screenIsSizeMove = false;
+	void ResizeScreen(int width, int height); // 스크린 리사이즈 이벤트시 호출
+	void ResizeResource();
 
 
 	// =============================================================

--- a/D3D11_1/21_ResizeScreen/DeferredRenderApp.h
+++ b/D3D11_1/21_ResizeScreen/DeferredRenderApp.h
@@ -212,6 +212,7 @@ public:
 	bool screenIsSizeMove = false;
 	void ResizeScreen(int width, int height); // 스크린 리사이즈 이벤트시 호출
 	void ResizeResource();
+	void ResetGBuffers();
 
 
 	// =============================================================

--- a/D3D11_1/21_ResizeScreen/FBXImporter.h
+++ b/D3D11_1/21_ResizeScreen/FBXImporter.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <string>
+
+class FBXImporter
+{
+	static void Import(std::string path, )
+};
+

--- a/D3D11_1/21_ResizeScreen/FBXResourceManager.cpp
+++ b/D3D11_1/21_ResizeScreen/FBXResourceManager.cpp
@@ -1,0 +1,336 @@
+#include "FBXResourceManager.h"
+
+#include <DirectXTex.h>
+#include <assimp\Importer.hpp>
+#include <assimp\scene.h>
+#include <assimp\postprocess.h>
+#include <filesystem>
+
+void FBXResourceManager::ProcessNode(std::shared_ptr<FBXResourceAsset>& pAsset, aiNode* pNode, const aiScene* pScene)
+{
+	string boneName = pNode->mName.C_Str();
+	BoneInfo boneInfo = pAsset->skeletalInfo.GetBoneInfoByName(boneName);
+	int boneIndex = pAsset->skeletalInfo.GetBoneIndexByName(boneName);
+
+	// node 추적
+	for (UINT i = 0; i < pNode->mNumMeshes; i++)
+	{
+		aiMesh* mesh = pScene->mMeshes[pNode->mMeshes[i]];
+		pAsset->meshes.push_back(this->ProcessMesh(pAsset, mesh, pScene));
+		pAsset->meshes.back().refBoneIndex = boneIndex;
+
+		pAsset->meshes.back().SetMaterial(pScene->mMaterials[mesh->mMaterialIndex]);
+
+		// weight 저장
+		ProcessBoneWeight(pAsset, mesh);
+	}
+
+	for (UINT i = 0; i < pNode->mNumChildren; i++)
+	{
+		this->ProcessNode(pAsset, pNode->mChildren[i], pScene);
+	}
+}
+
+Mesh FBXResourceManager::ProcessMesh(std::shared_ptr<FBXResourceAsset>& pAsset, aiMesh* pMesh, const aiScene* pScene)
+{
+	// Data to fill
+	std::vector<BoneWeightVertex> vertices;
+	std::vector<UINT> indices;
+	std::vector<Texture> textures;
+
+	// Walk through each of the mesh's vertices
+	for (UINT i = 0; i < pMesh->mNumVertices; i++)
+	{
+		BoneWeightVertex vertex{};
+
+		vertex.position = { pMesh->mVertices[i].x, pMesh->mVertices[i].y,  pMesh->mVertices[i].z };
+		vertex.normal = { pMesh->mNormals[i].x, pMesh->mNormals[i].y, pMesh->mNormals[i].z };
+		vertex.tangent = { pMesh->mTangents[i].x, pMesh->mTangents[i].y, pMesh->mTangents[i].z };
+		vertex.bitangent = { pMesh->mBitangents[i].x, pMesh->mBitangents[i].y, pMesh->mBitangents[i].z };
+
+		if (pMesh->mTextureCoords[0]) {
+			vertex.texture.x = (float)pMesh->mTextureCoords[0][i].x;
+			vertex.texture.y = (float)pMesh->mTextureCoords[0][i].y;
+		}
+
+		vertices.push_back(vertex);
+	}
+
+	// face 인덱스 저장
+	for (UINT i = 0; i < pMesh->mNumFaces; i++)
+	{
+		aiFace face = pMesh->mFaces[i];
+		if (face.mNumIndices != 3) continue; // 삼각형만
+
+		for (UINT j = 0; j < face.mNumIndices; j++)
+		{
+			int currIndex = face.mIndices[j];
+			indices.push_back(currIndex);
+		}
+	}
+
+	// 머터리얼 불러오기
+	if (pMesh->mMaterialIndex >= 0)
+	{
+		aiMaterial* material = pScene->mMaterials[pMesh->mMaterialIndex];
+
+		// diffuseMap 불러오기
+		std::vector<Texture> diffuseMaps = this->loadMaterialTextures(pAsset, material, aiTextureType_DIFFUSE, TEXTURE_DIFFUSE, pScene);
+		if (!diffuseMaps.empty())
+		{
+			textures.insert(textures.end(), diffuseMaps.begin(), diffuseMaps.end());
+		}
+
+		// emissiveMap 불러오기
+		std::vector<Texture> emissiveMaps = this->loadMaterialTextures(pAsset, material, aiTextureType_EMISSIVE, TEXTURE_EMISSIVE, pScene);
+		if (!emissiveMaps.empty())
+		{
+			textures.insert(textures.end(), emissiveMaps.begin(), emissiveMaps.end());
+		}
+
+		// normalMap 불러오기
+		std::vector<Texture> normalMaps = this->loadMaterialTextures(pAsset, material, aiTextureType_NORMALS, TEXTURE_NORMAL, pScene);
+		if (!normalMaps.empty())
+		{
+			textures.insert(textures.end(), normalMaps.begin(), normalMaps.end());
+		}
+
+		// specularMap 불러오기
+		std::vector<Texture> sepcualrMaps = this->loadMaterialTextures(pAsset, material, aiTextureType_SPECULAR, TEXTURE_SPECULAR, pScene);
+		if (!sepcualrMaps.empty())
+		{
+			textures.insert(textures.end(), sepcualrMaps.begin(), sepcualrMaps.end());
+		}
+
+		// metalnessMap 불러오기
+		std::vector<Texture> metalnessMap = this->loadMaterialTextures(pAsset, material, aiTextureType_METALNESS, TEXTURE_METALNESS, pScene);
+		if (!metalnessMap.empty())
+		{
+			textures.insert(textures.end(), metalnessMap.begin(), metalnessMap.end());
+		}
+
+		// roughnessMap 불러오기
+		std::vector<Texture> roughnessMap = this->loadMaterialTextures(pAsset, material, aiTextureType_DIFFUSE_ROUGHNESS, TEXTURE_ROUGHNESS, pScene);
+		if (!roughnessMap.empty())
+		{
+			textures.insert(textures.end(), roughnessMap.begin(), roughnessMap.end());
+		}
+
+		std::vector<Texture> shininessMap = this->loadMaterialTextures(pAsset, material, aiTextureType_SHININESS, TEXTURE_SHININESS, pScene);
+		if (!shininessMap.empty())
+		{
+			textures.insert(textures.end(), shininessMap.begin(), shininessMap.end());
+		}
+	}
+
+	return Mesh(m_device, vertices, indices, textures);
+}
+
+void FBXResourceManager::ProcessBoneWeight(std::shared_ptr<FBXResourceAsset>& pAsset, aiMesh* pMesh)
+{
+	UINT meshBoneCount = pMesh->mNumBones;
+	if (meshBoneCount <= 0) return;
+
+	for (UINT i = 0; i < meshBoneCount; i++)
+	{
+		aiBone* pAiBone = pMesh->mBones[i];
+		UINT boneIndex = pAsset->skeletalInfo.GetBoneIndexByName(pAiBone->mName.C_Str());
+		BoneInfo bone = pAsset->skeletalInfo.GetBoneInfoByIndex(boneIndex);
+
+		for (UINT j = 0; j < pAiBone->mNumWeights; j++)
+		{
+			UINT vertexId = pAiBone->mWeights[j].mVertexId;
+			float weight = pAiBone->mWeights[j].mWeight;
+			pAsset->meshes.back().vertices[vertexId].AddBoneData(boneIndex, weight);
+		}
+	}
+}
+
+std::vector<Texture> FBXResourceManager::loadMaterialTextures(std::shared_ptr<FBXResourceAsset>& pAsset, aiMaterial* mat, aiTextureType type, std::string typeName, const aiScene* scene)
+{
+	std::vector<Texture> textures;
+	for (UINT i = 0; i < mat->GetTextureCount(type); i++)
+	{
+		aiString str;
+		mat->GetTexture(type, i, &str);
+		// Check if texture was loaded before and if so, continue to next iteration: skip loading a new texture
+		bool skip = false;
+		auto textureloadeds = pAsset->textures;
+		for (UINT j = 0; j < textureloadeds.size(); j++)
+		{
+			if (std::strcmp(textureloadeds[j].path.c_str(), str.C_Str()) == 0) // path 확인
+			{
+				textures.push_back(textureloadeds[j]);
+				skip = true; // A texture with the same filepath has already been loaded, continue to next one. (optimization)
+				break;
+			}
+		}
+
+		if (!skip)
+		{   // If texture hasn't been loaded already, load it
+			HRESULT hr;
+			Texture texture;
+
+			const aiTexture* embeddedTexture = scene->GetEmbeddedTexture(str.C_Str());
+			if (embeddedTexture != nullptr)
+			{
+				loadEmbeddedTexture(embeddedTexture, texture.pTexture);
+			}
+			else
+			{
+				std::string filename = std::string(str.C_Str());
+				filename = pAsset->directory + '\\' + filename;
+				std::wstring filenamews = std::wstring(filename.begin(), filename.end());
+
+				std::filesystem::path p(filename);
+
+				if (p.extension() == ".tga")
+				{
+					DirectX::ScratchImage image;
+					ComPtr<ID3D11Resource> tgaTexture{};
+
+					HR_T(DirectX::LoadFromTGAFile(filenamews.c_str(), DirectX::TGA_FLAGS_NONE, nullptr, image)); // Load the TGA data
+					HR_T(DirectX::CreateTexture(m_device.Get(), image.GetImages(), image.GetImageCount(), image.GetMetadata(), tgaTexture.GetAddressOf())); // convert image to texture
+
+					HR_T(m_device.Get()->CreateShaderResourceView(tgaTexture.Get(), nullptr, texture.pTexture.GetAddressOf()));
+				}
+				else
+				{
+					HR_T(CreateWICTextureFromFile(m_device.Get(), m_deviceContext.Get(), filenamews.c_str(), nullptr, texture.pTexture.GetAddressOf())); 
+				}
+			}
+
+			texture.type = typeName;
+			texture.path = str.C_Str();
+			textures.push_back(texture);
+			textureloadeds.push_back(texture);  // Store it as texture loaded for entire model, to ensure we won't unnecesery load duplicate textures.
+		}
+	}
+	return textures;
+}
+
+void FBXResourceManager::loadEmbeddedTexture(const aiTexture* embeddedTexture, ComPtr<ID3D11ShaderResourceView>& outTexture)
+{
+	if (embeddedTexture->mHeight != 0)
+	{
+		// Load an uncompressed ARGB8888 embedded texture
+		D3D11_TEXTURE2D_DESC desc;
+		desc.Width = embeddedTexture->mWidth;
+		desc.Height = embeddedTexture->mHeight;
+		desc.MipLevels = 1;
+		desc.ArraySize = 1;
+		desc.SampleDesc.Count = 1;
+		desc.SampleDesc.Quality = 0;
+		desc.Usage = D3D11_USAGE_DEFAULT;
+		desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+		desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+		desc.CPUAccessFlags = 0;
+		desc.MiscFlags = 0;
+
+		D3D11_SUBRESOURCE_DATA subresourceData;
+		subresourceData.pSysMem = embeddedTexture->pcData;
+		subresourceData.SysMemPitch = embeddedTexture->mWidth * 4;
+		subresourceData.SysMemSlicePitch = embeddedTexture->mWidth * embeddedTexture->mHeight * 4;
+
+		ID3D11Texture2D* texture2D = nullptr;
+		HR_T(m_device->CreateTexture2D(&desc, &subresourceData, &texture2D));
+
+		HR_T(m_device->CreateShaderResourceView(texture2D, nullptr, outTexture.GetAddressOf()));
+	}
+	else
+	{
+		// mHeight is 0, so try to load a compressed texture of mWidth bytes
+		const size_t size = embeddedTexture->mWidth;
+
+		HR_T(CreateWICTextureFromMemory(m_device.Get(), m_deviceContext.Get(), reinterpret_cast<const unsigned char*>(embeddedTexture->pcData), size, nullptr, outTexture.GetAddressOf()));
+	}
+}
+
+std::shared_ptr<FBXResourceAsset> FBXResourceManager::LoadFBXByPath(ComPtr<ID3D11Device>& pDevice, ComPtr<ID3D11DeviceContext>& pDeviceContext, std::string path)
+{
+	// map에 먼저 있는지 확인
+	auto it = assets.find(path);
+
+	if (it != assets.end()) // 존재함
+	{
+		if (!it->second.expired())
+		{
+			shared_ptr<FBXResourceAsset> assetPtr = it->second.lock();
+			return assetPtr;
+		}
+		else
+		{
+			assets.erase(it); // 지우고 새로 만들기
+		}
+	}
+
+	Assimp::Importer importer;
+
+	unsigned int importFlag = aiProcess_Triangulate |	// 삼각형 변환
+		aiProcess_GenNormals |				// 노말 생성
+		aiProcess_GenUVCoords |				// UV 생성
+		aiProcess_CalcTangentSpace |		// 탄젠트 생성
+		aiProcess_LimitBoneWeights |		// 본의 영향을 받는 정점의 최대 개수 4개로 제한
+		aiProcess_ConvertToLeftHanded;		// 왼손 좌표계로 변환
+
+	importer.SetPropertyBool(AI_CONFIG_IMPORT_FBX_PRESERVE_PIVOTS, 0);
+
+	const aiScene* pScene = importer.ReadFile(path, importFlag);
+
+	assert(pScene && ".fbx not found");
+
+	this->m_device = pDevice;
+	this->m_deviceContext = pDeviceContext;
+
+	// 없으면 load후 map에 추가 
+	auto sharedAsset = make_shared<FBXResourceAsset>();
+
+	if (pScene == nullptr)
+		return nullptr;
+
+	sharedAsset ->directory = path.substr(0, path.find_last_of("/\\"));
+
+	// skeletonInfo 저장
+	sharedAsset ->skeletalInfo = SkeletonInfo();
+	sharedAsset ->skeletalInfo.CreateFromAiScene(pScene);
+
+	// animation 저장
+	int animationsNum = pScene->mNumAnimations;
+	for (int i = 0; i < animationsNum; i++)
+	{
+		Animation anim;
+		anim.CreateBoneAnimation(pScene->mAnimations[i]);
+		sharedAsset->animations.push_back(anim);
+	}
+
+	// mesh 저장, texture 저장 
+	ProcessNode(sharedAsset , pScene->mRootNode, pScene); // 내부에서 mesh의 텍스처 저장함
+
+	// mesh의 정점 버퍼, 인덱스 버퍼 생성
+	for (auto& mesh : sharedAsset->meshes)
+	{
+		mesh.CreateVertexBuffer(pDevice);
+		mesh.CreateIndexBuffer(pDevice);
+	}
+
+	// bone offest 버퍼 채우기
+	for (auto& bone : sharedAsset->skeletalInfo.m_bones)
+	{
+		Matrix offsetMat = Matrix::Identity;
+		std::string currBoneName = bone.name;
+		int boneIndex = sharedAsset->skeletalInfo.GetBoneIndexByName(currBoneName);
+
+		if (boneIndex > 0)
+		{
+			offsetMat = sharedAsset->skeletalInfo.GetBoneOffsetByName(currBoneName);
+		}
+
+		sharedAsset->m_BoneOffsets.boneOffset[boneIndex] = offsetMat;
+	}
+
+	// map에 저장하기
+	weak_ptr<FBXResourceAsset> weakAsset = sharedAsset;
+	assets.insert({ path, weakAsset });
+
+	return sharedAsset;
+}

--- a/D3D11_1/21_ResizeScreen/FBXResourceManager.h
+++ b/D3D11_1/21_ResizeScreen/FBXResourceManager.h
@@ -1,0 +1,58 @@
+#pragma once
+#include <map>
+#include <string>
+#include <memory>
+
+#include "Mesh.h"
+#include "TextureLoader.h"
+#include "SkeletonInfo.h"
+#include "Animation.h"
+
+struct BoneOffsetBuffer
+{
+	Matrix boneOffset[256];
+};
+
+struct FBXResourceAsset
+{
+	SkeletonInfo skeletalInfo;
+	std::vector<Animation> animations;
+	std::vector<Mesh> meshes;
+	std::vector<Texture> textures;
+
+	std::string directory = "";
+	BoneOffsetBuffer m_BoneOffsets{}; // skeletalInfo 본 위치 정보
+};
+
+class FBXResourceManager
+{
+	FBXResourceManager() = default;
+	~FBXResourceManager() = default;
+
+	FBXResourceManager(const FBXResourceManager&) = delete;
+	FBXResourceManager& operator=(const FBXResourceManager&) = delete;
+
+	// 해당 매니저에서 fbx를 읽는다.
+	// 이미 읽은 fbx는 map에 저장된다.
+	std::map<std::string, std::weak_ptr<FBXResourceAsset>> assets;
+
+	// texture 불러오기 위한 device, deviceContext
+	ComPtr<ID3D11Device> m_device = nullptr;
+	ComPtr<ID3D11DeviceContext> m_deviceContext = nullptr;
+
+	// 에셋 내용 로드 함수들
+	void ProcessNode(std::shared_ptr<FBXResourceAsset>& pAsset, aiNode* pNode, const aiScene* pScene);
+	Mesh ProcessMesh(std::shared_ptr<FBXResourceAsset>& pAsset, aiMesh* pMesh, const aiScene* pScene);
+	void ProcessBoneWeight(std::shared_ptr<FBXResourceAsset>& pAsset, aiMesh* pMesh);
+	std::vector<Texture> loadMaterialTextures(std::shared_ptr<FBXResourceAsset>& pAsset, aiMaterial* mat, aiTextureType type, std::string typeName, const aiScene* scene);
+	void loadEmbeddedTexture(const aiTexture* embeddedTexture, ComPtr<ID3D11ShaderResourceView>& outTexture);
+
+public:
+	static FBXResourceManager& Instance()
+	{
+		static FBXResourceManager manager;
+		return manager;
+	}
+
+	std::shared_ptr<FBXResourceAsset> LoadFBXByPath(ComPtr<ID3D11Device>& pDevice, ComPtr<ID3D11DeviceContext>& pDeviceContext, std::string path);
+};

--- a/D3D11_1/21_ResizeScreen/Mesh.cpp
+++ b/D3D11_1/21_ResizeScreen/Mesh.cpp
@@ -1,0 +1,143 @@
+#include "Mesh.h"
+
+void Mesh::Draw(ComPtr<ID3D11DeviceContext>& pDeviceContext)
+{
+    
+    // ps ÃÊ±âÈ­ 
+    ID3D11ShaderResourceView* nullSRV[4] = { nullptr };
+    pDeviceContext->PSSetShaderResources(0, 4, nullSRV);
+
+    ID3D11ShaderResourceView* nullSRV2[2] = { nullptr };
+    pDeviceContext->PSSetShaderResources(6, 2, nullSRV);
+    
+    UINT stride = sizeof(BoneWeightVertex);
+    UINT offset = 0;
+    
+    pDeviceContext->IASetVertexBuffers(0, 1, m_pVertexBuffer.GetAddressOf(), &stride, &offset);
+    pDeviceContext->IASetIndexBuffer(m_pIndexBuffer.Get(), DXGI_FORMAT_R32_UINT, 0);        
+    
+    int textureCount = textures.size();
+    for (int i = 0; i < textureCount; i++)
+    {
+        ProcessTextureByType(pDeviceContext, i);
+    }
+    
+    pDeviceContext->DrawIndexed(static_cast<UINT>(indices.size()), 0, 0);
+    
+}
+
+void Mesh::SetMaterial(aiMaterial* pAiMaterial)
+{
+    aiColor4D color(0, 0, 0, 0);
+    if (AI_SUCCESS == pAiMaterial->Get(AI_MATKEY_COLOR_DIFFUSE, color)) //
+    {
+        material.diffuse = { color.r, color.g, color.b, color.a };
+    }
+}
+
+void Mesh::setupMesh()
+{
+    // check texture
+    for (auto& tex : textures)
+    {
+        string typeName = tex.type;
+        if (typeName == TEXTURE_DIFFUSE)
+        {
+            material.hasDiffuse = true;
+        }
+        else if (typeName == TEXTURE_EMISSIVE)
+        {
+            material.hasEmissive = true;
+        }
+        else if (typeName == TEXTURE_NORMAL)
+        {
+            material.hasNormal = true;
+        }
+        else if (typeName == TEXTURE_SPECULAR)
+        {
+            material.hasSpecular = true;
+        }
+        else if (typeName == TEXTURE_METALNESS)
+        {
+            material.hasMatalness = true;
+        }
+        else if (typeName == TEXTURE_ROUGHNESS)
+        {
+            material.hasRoughness= true;
+        }
+        else if (typeName == TEXTURE_SHININESS)
+        {
+            material.hasShininess = true;
+        }
+    }
+}
+
+void Mesh::ProcessTextureByType(ComPtr<ID3D11DeviceContext>& pDeviceContext, int index)
+{
+    string typeName = textures[index].type;
+
+    if (typeName == TEXTURE_DIFFUSE)
+    {
+        pDeviceContext->PSSetShaderResources(0, 1, textures[index].pTexture.GetAddressOf());
+    }
+    else if (typeName == TEXTURE_EMISSIVE)
+    {
+        pDeviceContext->PSSetShaderResources(1, 1, textures[index].pTexture.GetAddressOf());
+    }
+    else if (typeName == TEXTURE_NORMAL)
+    {
+        pDeviceContext->PSSetShaderResources(2, 1, textures[index].pTexture.GetAddressOf());
+    }
+    else if (typeName == TEXTURE_SPECULAR)
+    {
+        pDeviceContext->PSSetShaderResources(3, 1, textures[index].pTexture.GetAddressOf());
+    }
+    else if (typeName == TEXTURE_METALNESS)
+    {
+        pDeviceContext->PSSetShaderResources(6, 1, textures[index].pTexture.GetAddressOf());
+    }
+    else if (typeName == TEXTURE_ROUGHNESS)
+    {
+        pDeviceContext->PSSetShaderResources(7, 1, textures[index].pTexture.GetAddressOf());
+    }
+    else if (typeName == TEXTURE_SHININESS)
+    {
+        pDeviceContext->PSSetShaderResources(7, 1, textures[index].pTexture.GetAddressOf());
+    }
+}
+
+Material& Mesh::GetMaterial()
+{
+    return material;
+}
+
+void Mesh::CreateVertexBuffer(ComPtr<ID3D11Device>& dev)
+{
+    // vertex buffer
+    D3D11_BUFFER_DESC vbd = {};
+    vbd.Usage = D3D11_USAGE_IMMUTABLE;
+    vbd.ByteWidth = static_cast<UINT>(sizeof(BoneWeightVertex) * vertices.size());
+    vbd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+    vbd.CPUAccessFlags = 0;
+    vbd.MiscFlags = 0;
+
+    D3D11_SUBRESOURCE_DATA initData{};
+    initData.pSysMem = &vertices[0];
+
+    HR_T(dev->CreateBuffer(&vbd, &initData, m_pVertexBuffer.GetAddressOf()));
+}
+
+void Mesh::CreateIndexBuffer(ComPtr<ID3D11Device>& dev)
+{
+    // index buffer
+    D3D11_BUFFER_DESC ibd = {};
+    ibd.Usage = D3D11_USAGE_IMMUTABLE;
+    ibd.ByteWidth = static_cast<UINT>(sizeof(UINT) * indices.size());
+    ibd.BindFlags = D3D11_BIND_INDEX_BUFFER;
+    ibd.CPUAccessFlags = 0;
+    ibd.MiscFlags = 0;
+
+    D3D11_SUBRESOURCE_DATA initData{};
+    initData.pSysMem = &indices[0];
+    HR_T(dev->CreateBuffer(&ibd, &initData, m_pIndexBuffer.GetAddressOf()));
+}

--- a/D3D11_1/21_ResizeScreen/Mesh.h
+++ b/D3D11_1/21_ResizeScreen/Mesh.h
@@ -1,0 +1,119 @@
+#pragma once
+#include <wrl/client.h> // comptr
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <vector>
+#include <stdexcept>
+#include <d3d11_1.h>
+#include <directxtk/SimpleMath.h> // directXmath 대신 사용
+#include "../Common/Helper.h"
+#include "assimp/material.h"
+
+using namespace std;
+using namespace DirectX::SimpleMath;
+using namespace DirectX;
+using Microsoft::WRL::ComPtr;
+
+const string TEXTURE_DIFFUSE = "texture_diffuse";
+const string TEXTURE_EMISSIVE = "texture_emissive";
+const string TEXTURE_NORMAL = "texture_normal";
+const string TEXTURE_SPECULAR = "texture_specular";
+const string TEXTURE_METALNESS = "texture_metalness";
+const string TEXTURE_ROUGHNESS = "texture_roughness";
+const string TEXTURE_SHININESS = "texture_shininess";
+
+struct BoneWeightVertex
+{
+    Vector3 position;
+    Vector2 texture;
+    Vector3 tangent;
+    Vector3 bitangent;
+    Vector3 normal;
+	int BlendIndeces[4] = {};	// 참조하는 본 인덱스들
+	float BlendWeights[4] = {};	// 가중치의 총 합은 1이여야한다.
+
+	void AddBoneData(int boneIndex, float weight)
+	{
+		assert(BlendWeights[0] == 0.0f ||
+			BlendWeights[1] == 0.0f ||
+			BlendWeights[2] == 0.0f ||
+			BlendWeights[3] == 0.0f);
+
+		for (int i = 0; i < 4; i++)
+		{
+			if (BlendWeights[i] == 0.0f)
+			{
+				BlendIndeces[i] = boneIndex;
+				BlendWeights[i] = weight;
+				return;
+			}
+		}
+	}
+};
+
+struct Texture
+{
+	string type;
+	string path;
+
+	ComPtr<ID3D11ShaderResourceView> pTexture = nullptr;
+};
+
+struct Material
+{
+	Vector4 ambient = { 1.0f, 1.0f, 1.0f, 1.0f };
+    Vector4 diffuse = { 1.0f, 1.0f, 1.0f, 1.0f };
+    Vector4 specular = { 1.0f, 1.0f, 1.0f, 1.0f };
+
+    BOOL hasDiffuse = false;
+    BOOL hasEmissive = false;
+    BOOL hasNormal = false;
+    BOOL hasSpecular = false;
+
+	BOOL hasMatalness = false;
+	BOOL hasRoughness = false;
+	BOOL hasShininess = false;
+	INT pad;
+};
+
+class Mesh
+{
+public:
+	vector<BoneWeightVertex> vertices;
+	vector<UINT> indices;
+	vector<Texture> textures;
+
+	ComPtr<ID3D11Device> m_device;
+	int refBoneIndex = -1;
+
+	Mesh(ComPtr<ID3D11Device>& dev, const std::vector<BoneWeightVertex>& vertices, const std::vector<UINT>& indices, const std::vector<Texture>& textures) :
+		vertices(vertices),
+		indices(indices),
+		textures(textures),
+		m_device(dev),
+		m_pVertexBuffer(nullptr),
+		m_pIndexBuffer(nullptr)
+	{
+		this->setupMesh();
+	}
+
+    void Draw(ComPtr<ID3D11DeviceContext>& pDeviceContext);
+	void SetMaterial(aiMaterial* pAiMaterial);
+	Material& GetMaterial();
+	void CreateVertexBuffer(ComPtr<ID3D11Device>& dev);
+	void CreateIndexBuffer(ComPtr<ID3D11Device>& dev);
+
+private:
+	Material material{};
+
+	ComPtr<ID3D11Buffer> m_pVertexBuffer{};
+	ComPtr<ID3D11Buffer> m_pIndexBuffer{};
+
+    // Functions
+    // Initializes all the buffer objects/arrays
+    void setupMesh();
+
+	void ProcessTextureByType(ComPtr<ID3D11DeviceContext>& pDeviceContext, int index);
+};

--- a/D3D11_1/21_ResizeScreen/Shaders/PS_DepthOnlyPass.hlsl
+++ b/D3D11_1/21_ResizeScreen/Shaders/PS_DepthOnlyPass.hlsl
@@ -1,0 +1,15 @@
+#include <Shared.hlsli>
+
+float main(PS_INPUT_MODEL input) : SV_Depth
+{
+    float alpha = txDiffuse.Sample(samLinear, input.Tex).a;
+    if(!hasDiffuse)
+    {
+        alpha = 1.0f;
+        return input.PosCS.z;
+    }
+    
+    clip(alpha - 0.5f);
+    
+    return input.PosCS.z; // 색상 기록은 안함.
+}

--- a/D3D11_1/21_ResizeScreen/Shaders/PS_DirectionalLight.hlsl
+++ b/D3D11_1/21_ResizeScreen/Shaders/PS_DirectionalLight.hlsl
@@ -1,0 +1,155 @@
+#include "Shared.hlsli"
+
+static const float PI = 3.141592;
+static const float Epsilon = 0.00001;
+
+// D(h) (Normal Distribution Function) : Trowbridge-Reitz GGX
+float NDFGGXTR(float3 normal, float3 halfVec, float roughness)
+{
+    float cosLh = dot(normal, halfVec);
+    float alpha = roughness * roughness;
+    float alphaSq = alpha * alpha;
+    
+    float demon = PI * pow((cosLh * cosLh) * (alphaSq - 1) + 1, 2);
+    
+    return alphaSq / demon;
+}
+
+// F(v, h) Fresnel equation : Fresnel-Schlick approximation 
+float3 FresnelSchlick(float3 F0, float cosTheta) // F0 == relfection factor
+{
+    return F0 + (1.0 - F0) * pow(1.0 - cosTheta, 5.0);
+}
+
+// G(l,v,h) 
+float GSchlickGGX(float3 norm, float3 viewVec, float k) // K : 블러 감소 인자
+{
+    float NdotV = dot(norm, viewVec);
+    float denom = NdotV * (1.0 - k) + k;
+    return NdotV / denom;
+}
+
+// G(n, v, l, k) : Smith's Method
+float GSmithMethod(float3 norm, float3 viewVec, float3 lightVec, float roughness)
+{
+    float kDir = (roughness + 1) * (roughness + 1); // for directional lighting
+    //float kIBL = roughness* roughness / 2.0;          // IBL lighting
+    kDir /= 8.0;
+    
+    return GSchlickGGX(norm, viewVec, kDir) * GSchlickGGX(norm, lightVec, kDir);
+}
+
+float4 main(PS_INPUT_QUAD input) : SV_TARGET
+{    
+    float2 uv = input.tex;
+    
+    // gbuffer texture sample
+    float3 baseColor = geoBufferBaseColor.Sample(samPoint, uv).rgb; // BaseColor
+    float3 normalEncoded = geoBufferNormal.Sample(samPoint, uv).rgb; // normalEncoded
+    float3 worldSpacePos = geoBufferPosition.Sample(samPoint, uv).xyz; // WS
+    float metal = geoBufferMetal.Sample(samPoint, uv).r; // metal cubemap
+    float rough = geoBufferRough.Sample(samPoint, uv).r; // rough cubemap    
+    float specularIntensity = geoBufferSpecular.Sample(samPoint, uv).r; // specular
+    float4 emission = geoBufferEmission.Sample(samPoint, uv); // emission
+    
+    float3 finalNorm = normalize(DecodeNormal(normalEncoded));
+    float finalRoughness = max(0.1, rough);
+    
+    float3 lightDirWorld = normalize(-LightDirection.xyz);
+    float intensity = LightDirection.w;
+    
+    float3 lightColor = LightColor.rgb;
+    
+    float3 Lo = normalize((float3) CameraPos - (float3) worldSpacePos); // 빛이 눈으로 가는 방향 : 현재 위치 -> eye ( view Vector )
+
+    float3 Li = normalize(lightDirWorld); // 빛 방향
+    float3 Lh = normalize(Li + Lo); // half-vector between Li and Lo        
+    
+    float NdotL = saturate(dot(finalNorm, Li)); // dot(Normal, Light Direction)
+    float NdotO = saturate(dot(finalNorm, Lo)); // dot(Normal, View)
+    
+    // 그림자처리 부분 =====================================================================
+    float finalShadow = 1.0f;
+    // Light Space
+    float4 positionShadow = mul(float4(worldSpacePos, 1.0f), ShadowView);
+    positionShadow = mul(positionShadow, ShadowProjection);
+
+    // NDC depth
+    float currentShadowDepth = positionShadow.z / positionShadow.w;
+
+    // Shadow UV
+    float2 shadowUV = positionShadow.xy / positionShadow.w;
+    shadowUV.y = -shadowUV.y;
+    shadowUV = shadowUV * 0.5f + 0.5f;
+    
+    // NDC좌표계에서 Texture 좌표계로 변환
+    if (shadowUV.x >= 0.0 && shadowUV.x <= 1.0 && shadowUV.y >= 0.0 && shadowUV.y <= 1.0)
+    {
+        float sampleShadowDepth = txShadow.Sample(samLinear, shadowUV).r;
+        
+        // currentShadowDepth가 더 크면 뒤 쪽에 있으므로 직접광 차단
+        if (currentShadowDepth > sampleShadowDepth + 0.001)
+        {
+            finalShadow = 0.0f;
+        }
+    }    
+    
+    // =============================================
+    
+    float3 directLighting = 0.0f;
+    
+    // Cook-Torrance Specular BRDF   
+
+    
+    // 기본 반사율(F0) = lerp(비금속 평균 반사, baseColor(텍스처), matalness)
+    float3 F0 = lerp(float3(0.04, 0.04, 0.04), (float3) baseColor, metal);
+    
+    {   
+        float D = NDFGGXTR(finalNorm, Lh, finalRoughness);
+        float3 F = FresnelSchlick(F0, max(0, dot(Lh, Lo)));
+        float G = GSmithMethod(finalNorm, Lo, Li, finalRoughness);
+    
+        // 표면 산란
+        float3 kd = lerp(float3(1, 1, 1) - F, float3(0, 0, 0), metal);
+    
+        // Lambert diffuse BRDF  
+        float3 diffuseBRDF = kd * (float3) baseColor / PI;
+    
+        // specular BRDF
+        float3 specularBRDF = (D * F * G) / max(Epsilon, 4.0 * NdotL * NdotO);
+        
+        directLighting = (diffuseBRDF + specularBRDF * specularIntensity) * NdotL * finalShadow * lightColor * intensity; + (float3) emission;
+    }
+    
+    
+   float3 inDirectLighting = 0.0f;
+   // IBL
+   {
+        float3 irradiance = txIBLIrradiance.Sample(samLinear, finalNorm).rgb;
+        
+        // IBL diffuse    
+        float3 F = FresnelSchlick(F0, NdotO);
+        float3 kd = lerp(1.0 - F, 0.0, metal);
+        
+        float3 diffuseIBL = kd * (float3)baseColor * irradiance / PI; // irradiance map이 1/pi가 포함되어있으면 제거 있으면 1/pi 추가하기
+        
+        // IBL specular        
+        uint specularTexureLevels, width, height;        
+        txIBLSepcualar.GetDimensions(0, width, height, specularTexureLevels);       
+        
+        float3 R = reflect(-Lo, finalNorm);
+        
+        float lodLevel = finalRoughness * (float)(specularTexureLevels) - 1;
+        float3 PrefilteredColor = txIBLSepcualar.SampleLevel(samLinear, R, lodLevel).rgb;
+        
+        // dot(Normal,View) , roughness를 텍셀좌표로 미리계산된 F*G , G 평균값을 샘플링한다  
+        float2 specularBRDF = txIBLLookUpTable.Sample(samLinear, float2(NdotO, finalRoughness)).rg;
+        
+        // 쿡토런스 Spceular BRDF 근사식
+        float3 specularIBL = PrefilteredColor * (F0 * specularBRDF.x + specularBRDF.y); // x : normal dot view, y : roughtness
+        
+        inDirectLighting = (diffuseIBL + specularIBL);
+   }
+    
+    return float4(pow(float3(directLighting + inDirectLighting), 1.0 / 2.2), 1.0); // linear -> gamma    
+}

--- a/D3D11_1/21_ResizeScreen/Shaders/PS_GBuffer.hlsl
+++ b/D3D11_1/21_ResizeScreen/Shaders/PS_GBuffer.hlsl
@@ -1,0 +1,83 @@
+#include <Shared.hlsli>
+
+struct GBufferOut
+{
+    float4 Albedo   : SV_Target0;
+    float4 Normal   : SV_Target1;
+    float4 Position : SV_Target2;
+    float1 Metal    : SV_Target3;
+    float1 Rough    : SV_Target4;
+    float1 Specular : SV_Target5;
+    float4 Emission : SV_Target6;
+};
+
+GBufferOut main(PS_INPUT_MODEL input)
+{
+    GBufferOut gOut;
+    gOut.Position = float4(input.PosWS, 1.0f);
+    
+    // 광원처리 부분 =====================================================================
+    // base(diffuse) texture Sampling 
+    float4 albedo = txDiffuse.Sample(samLinear, input.Tex);
+    if (!hasDiffuse)
+    {
+        albedo = BaseColor;
+    }
+    
+    if (albedo.a < 0.5f) // alpha cliping
+        discard;
+    
+    albedo.rgb = pow(albedo.rgb, 2.2); // gamma -> linear
+    gOut.Albedo = albedo;
+    
+    // specularSample
+    float specularIntensity = txSpec.Sample(samLinear, input.Tex).r;
+    if (!hasSpecular)
+    {
+        specularIntensity = 1.0f;
+    }
+    gOut.Specular = specularIntensity;
+    
+    // EmissionSample
+    float4 textureEmission = txEmission.Sample(samLinear, input.Tex);
+    if (!hasEmissive)
+    {
+        textureEmission = float4(0.0f, 0.0f, 0.0f, 0.0f);
+    }
+    gOut.Emission = textureEmission;
+    
+    // normalSample
+    float3x3 TBN = float3x3(input.Tangent, input.Bitangent, input.NormWS);
+    float3 normalMapSample = txNormal.Sample(samLinear, input.Tex).rgb;
+    // normal map이 없을 경우를 대비
+    if (!hasNormal)
+    {
+        normalMapSample = float3(0.5f, 0.5f, 1.0f); // flat normal (no perturbation)
+    }
+    float3 normalTexture = normalize(DecodeNormal(normalMapSample)); //  Convert normal map color (RGB [0,1]) to normal vector in range [-1,1] 
+    float3 TBNSpace = normalize(mul(normalTexture, TBN));  
+    float3 finalNorm = float4(EncodeNormal(TBNSpace), 1.0f);
+    gOut.Normal = float4(finalNorm, 1.0f);
+    
+    // MetalnessSample
+    float metalnessSample = txMetalness.Sample(samLinear, input.Tex).r; // grayScale
+    if(!hasMetalness)
+    {
+        metalnessSample = 1;
+    }
+    
+    float finalMetalness = metalnessSample * Metalness;
+    gOut.Metal = finalMetalness;
+    
+    // RoughnessSample
+    float roughnessSample = txRoughness.Sample(samLinear, input.Tex).r; // grayScale
+    if(!hasRoughness)
+    {
+        roughnessSample = hasShininess ? 1 - roughnessSample : 1;
+    }
+    
+    float finalRoughness = roughnessSample * Roughness;
+    gOut.Rough = finalRoughness;
+    
+    return gOut;    
+}

--- a/D3D11_1/21_ResizeScreen/Shaders/PS_Skybox.hlsl
+++ b/D3D11_1/21_ResizeScreen/Shaders/PS_Skybox.hlsl
@@ -1,0 +1,8 @@
+#include "Shared.hlsli"
+
+float4 main(PS_INPUT_Sky input) : SV_TARGET
+{
+    float4 diffuse_texture = txCubemap.Sample(samLinear, input.Pos);
+    return diffuse_texture;
+
+}

--- a/D3D11_1/21_ResizeScreen/Shaders/PS_Solid.hlsl
+++ b/D3D11_1/21_ResizeScreen/Shaders/PS_Solid.hlsl
@@ -1,0 +1,4 @@
+float4 main() : SV_TARGET
+{
+	return float4(1.0f, 1.0f, 1.0f, 1.0f);
+}

--- a/D3D11_1/21_ResizeScreen/Shaders/Shared.hlsli
+++ b/D3D11_1/21_ResizeScreen/Shaders/Shared.hlsli
@@ -1,0 +1,165 @@
+//--------------------------------------------------------------------------------------
+// Constant Buffer Variables
+//--------------------------------------------------------------------------------------
+
+SamplerState samLinear      : register(s0);
+SamplerState samPoint       : register(s1);
+
+Texture2D txDiffuse         : register(t0);   // 
+Texture2D txEmission        : register(t1);   // Emission 
+Texture2D txNormal          : register(t2);   // 노멀맵 텍스처
+Texture2D txSpec            : register(t3);   // 스펙큘러맵 텍스처
+Texture2D txShadow          : register(t4);   // 그림자 매핑 텍스처
+TextureCube txCubemap       : register(t5);   // skybox용 큐브맵 텍스처
+
+Texture2D txMetalness       : register(t6);   // metalness 텍스처
+Texture2D txRoughness       : register(t7);   // roughness 텍스처
+
+TextureCube txIBLIrradiance : register(t8);   // IBL Irrandiance Map
+TextureCube txIBLSepcualar  : register(t9);   // IBL Specular Map
+Texture2D txIBLLookUpTable  : register(t10);  // IBL LUT (Look Up Table)
+
+Texture2D geoBufferBaseColor: register(t11);  // gbuffer basecolor texture
+Texture2D geoBufferNormal   : register(t12);  // gbuffer normal texture
+Texture2D geoBufferPosition : register(t13);  // gbuffer worldSpace position texture
+Texture2D geoBufferMetal    : register(t14);  // gbuffer metalness
+Texture2D geoBufferRough    : register(t15);  // gbuffer roughness
+Texture2D geoBufferShadow   : register(t16);  // gbuffer shadow
+Texture2D geoBufferSpecular : register(t17);  // gbuffer specular
+Texture2D geoBufferEmission : register(t18);  // gbuffer emission
+
+cbuffer ConstantBuffer : register(b0)   // PerFrame
+{
+    matrix View;
+    matrix Projection;
+    
+    matrix ShadowView;
+    matrix ShadowProjection;    
+    
+    float4 LightAmbient;    // 환경광
+    float4 LightDiffuse;    // 난반사
+    float4 LightSpecular;   // 정반사    
+    float Shininess;        // 광택지수
+    float3 CameraPos;       // 카메라 위치        
+    
+    float Metalness;
+    float Roughness;
+    float2 pad;
+    
+    float4 BaseColor;
+}
+
+cbuffer Material : register(b1) // PerMaterial
+{
+    float4 matAmbient;
+    float4 matDiffuse;
+    float4 matSpecular;  
+    
+    int hasDiffuse;
+    int hasEmissive;
+    int hasNormal;
+    int hasSpecular;
+    
+    int hasMetalness;
+    int hasRoughness;    
+    int hasShininess;    
+    float pad2;
+};
+
+cbuffer ModelTransform : register(b2)
+{
+    matrix World;        
+    
+    int isRigid; // 1 : rigid, 0 : skinned
+    int refBoneIndex; // 리지드일 때 참조하는 본 인덱스
+    float pad3;
+    float pad4;
+}
+
+cbuffer BonePoseMatrix : register(b3) 
+{
+    matrix bonePose[256]; // skeleton pose matrix -> animation updated matrix
+}
+
+cbuffer BoneOffsetMatrix : register(b4)
+{
+    matrix boneOffset[256]; // model transform
+}
+
+cbuffer DirectionalLightCB : register(b5)
+{
+    float4 LightDirection;
+    float4 LightColor; 
+}
+
+// Basic Shader Struct =============================================================
+
+struct VS_INPUT_MODEL
+{
+    float4 Pos : POSITION;
+    float2 Tex : TEXCOORD;   
+    
+    float3 Tangent : TANGENT;
+    float3 Bitangent : BINORMAL;    
+    float3 Norm : NORMAL;
+    
+    int4 BlendIndices : BLENDINDICES;
+    float4 BlendWeights : BLENDWEIGHTS;
+};
+
+struct PS_INPUT_MODEL
+{
+    float4 PosCS : SV_POSITION;   // clip space position    
+    
+    float3 NormWS : NORMAL;       // world space normal
+    float2 Tex : TEXCOORD;      // 텍스처 UV좌표
+    float3 PosWS : TEXCOORD2;   // world space position
+    
+    float3 Tangent : TANGENT;
+    float3 Bitangent : BINORMAL;    
+}; 
+
+struct VS_INPUT_sky
+{
+    float3 Pos : POSITION;
+};
+
+struct PS_INPUT_Sky
+{
+    float4 PosClipSpace : SV_POSITION;
+    float3 Pos : POSITION;
+};
+
+struct VS_INPUT_QUAD
+{
+    float3 position : POSITION; // ndc
+    float2 tex : TEXCOORD;
+};
+
+struct PS_INPUT_QUAD
+{
+    float4 position : SV_POSITION;
+    float2 tex : TEXCOORD;    
+};
+
+// Functions =======================================================================
+float3 EncodeNormal(float3 N)
+{
+    return N * 0.5 + 0.5;
+}
+
+float3 DecodeNormal(float3 N)
+{
+    return N * 2 - 1;
+}
+
+float3 ACESFilm(float3 x)
+{
+    float a = 2.51f;
+    float b = 0.03f;
+    float c = 2.43f;
+    float d = 0.59f;
+    float e = 0.14f;
+    
+    return saturate((x * (a * x + b)) / (x * (c * x + d) + e));
+}

--- a/D3D11_1/21_ResizeScreen/Shaders/VS_DepthOnlyPass.hlsl
+++ b/D3D11_1/21_ResizeScreen/Shaders/VS_DepthOnlyPass.hlsl
@@ -1,0 +1,38 @@
+#include <Shared.hlsli>
+
+PS_INPUT_MODEL main(VS_INPUT_MODEL input)
+{
+    PS_INPUT_MODEL output = (PS_INPUT_MODEL) 0;       
+    Matrix ModelToWorld;
+    if(isRigid == 0)
+    {
+        // offsetMatrix * poseMatrix
+        float4x4 OffsetPose[4];
+        OffsetPose[0] = mul(boneOffset[input.BlendIndices.x], bonePose[input.BlendIndices.x]);
+        OffsetPose[1] = mul(boneOffset[input.BlendIndices.y], bonePose[input.BlendIndices.y]);
+        OffsetPose[2] = mul(boneOffset[input.BlendIndices.z], bonePose[input.BlendIndices.z]);
+        OffsetPose[3] = mul(boneOffset[input.BlendIndices.w], bonePose[input.BlendIndices.w]);
+    
+        // 4개를 가중치 누적 합으로 변경
+        float4x4 WeightOffsetPose;
+        WeightOffsetPose = mul(input.BlendWeights.x, OffsetPose[0]);
+        WeightOffsetPose += mul(input.BlendWeights.y, OffsetPose[1]);
+        WeightOffsetPose += mul(input.BlendWeights.z, OffsetPose[2]);
+        WeightOffsetPose += mul(input.BlendWeights.w, OffsetPose[3]);
+        
+        ModelToWorld = mul(WeightOffsetPose, World);        
+    }
+    else if(isRigid == 1)
+    {
+        ModelToWorld = mul(bonePose[refBoneIndex], World); 
+    }  
+    
+    // model -> world space 
+    output.PosCS = mul(input.Pos, ModelToWorld);
+    output.PosCS = mul(output.PosCS, ShadowView);
+    output.PosCS = mul(output.PosCS, ShadowProjection);   
+    
+    output.Tex = input.Tex;
+    
+    return output;
+}

--- a/D3D11_1/21_ResizeScreen/Shaders/VS_DirectionalLight.hlsl
+++ b/D3D11_1/21_ResizeScreen/Shaders/VS_DirectionalLight.hlsl
@@ -1,0 +1,10 @@
+#include "Shared.hlsli"
+
+PS_INPUT_QUAD main(VS_INPUT_QUAD input)
+{    
+    PS_INPUT_QUAD output = (PS_INPUT_QUAD) 0;
+    output.position = float4(input.position.xy, 0.0f, 1.0f);
+    output.tex = input.tex;
+    
+    return output;
+}

--- a/D3D11_1/21_ResizeScreen/Shaders/VS_GBuffer.hlsl
+++ b/D3D11_1/21_ResizeScreen/Shaders/VS_GBuffer.hlsl
@@ -1,0 +1,45 @@
+#include <Shared.hlsli>
+
+PS_INPUT_MODEL main(VS_INPUT_MODEL input)
+{
+    PS_INPUT_MODEL output = (PS_INPUT_MODEL) 0;
+    
+    Matrix ModelToWorld;
+    if (isRigid == 0)
+    {
+        // offsetMatrix * poseMatrix
+        float4x4 OffsetPose[4];
+        OffsetPose[0] = mul(boneOffset[input.BlendIndices.x], bonePose[input.BlendIndices.x]);
+        OffsetPose[1] = mul(boneOffset[input.BlendIndices.y], bonePose[input.BlendIndices.y]);
+        OffsetPose[2] = mul(boneOffset[input.BlendIndices.z], bonePose[input.BlendIndices.z]);
+        OffsetPose[3] = mul(boneOffset[input.BlendIndices.w], bonePose[input.BlendIndices.w]);
+    
+        // 4개를 가중치 누적 합으로 변경
+        float4x4 WeightOffsetPose;
+        WeightOffsetPose = mul(input.BlendWeights.x, OffsetPose[0]);
+        WeightOffsetPose += mul(input.BlendWeights.y, OffsetPose[1]);
+        WeightOffsetPose += mul(input.BlendWeights.z, OffsetPose[2]);
+        WeightOffsetPose += mul(input.BlendWeights.w, OffsetPose[3]);
+        
+        ModelToWorld = mul(WeightOffsetPose, World);
+    }
+    else if (isRigid == 1)
+    {
+        ModelToWorld = mul(bonePose[refBoneIndex], World); 
+        // ModelToWorld = World;
+    }
+    
+    // model -> world space    
+    float4 worldPos = mul(input.Pos, ModelToWorld);
+    output.PosWS = worldPos.xyz;
+    float4 PosVS = mul(worldPos, View); // view space
+    output.PosCS = mul(PosVS, Projection);
+
+    output.NormWS = normalize(mul(input.Norm, (float3x3) ModelToWorld));
+    output.Tangent = normalize(mul(input.Tangent, (float3x3) ModelToWorld));
+    output.Bitangent = normalize(mul(input.Bitangent, (float3x3) ModelToWorld));
+
+    output.Tex = input.Tex;
+    
+    return output;
+} 

--- a/D3D11_1/21_ResizeScreen/Shaders/VS_Skybox.hlsl
+++ b/D3D11_1/21_ResizeScreen/Shaders/VS_Skybox.hlsl
@@ -1,0 +1,22 @@
+#include "Shared.hlsli"
+
+PS_INPUT_Sky main(VS_INPUT_sky input)
+{	
+    PS_INPUT_Sky output = (PS_INPUT_Sky) 0;
+    
+    float4 pos = float4(input.Pos, 1.0f);
+    Matrix ViewWithoutTranlation = View;
+    
+    ViewWithoutTranlation._41 = 0;
+    ViewWithoutTranlation._42 = 0;
+    ViewWithoutTranlation._43 = 0;
+    
+    pos = mul(pos, ViewWithoutTranlation);
+    pos = mul(pos, Projection);    
+    pos.z = pos.w; // 항상 뒤에서 그리기 (fixed depth)
+    
+    output.PosClipSpace = pos;
+    output.Pos = normalize(input.Pos);     
+    
+	return output;
+}

--- a/D3D11_1/21_ResizeScreen/SkeletalModel.cpp
+++ b/D3D11_1/21_ResizeScreen/SkeletalModel.cpp
@@ -1,0 +1,147 @@
+#include "SkeletalModel.h"
+#include "../Common/Helper.h"
+#include "../Common/TimeSystem.h"
+
+SkeletalModel::SkeletalModel()
+{
+}
+
+SkeletalModel::~SkeletalModel()
+{
+}
+
+bool SkeletalModel::Load(HWND hwnd, ComPtr<ID3D11Device>& pDevice, ComPtr<ID3D11DeviceContext>& pDeviceContext, std::string filename)
+{
+	this->directory = filename.substr(0, filename.find_last_of("/\\"));
+	this->m_device = pDevice;
+	this->m_deviceContext = pDeviceContext;
+	this->hwnd = hwnd;
+
+	// 리소스 매니저에서 FBX 정보 가져오기 -> 어디서?
+	modelAsset = FBXResourceManager::Instance().LoadFBXByPath(pDevice, pDeviceContext, filename);
+
+	// 인스턴스 데이터 생성하기 ( 본 데이터 )
+	CreateBoneInfos();
+
+	return true;
+}
+
+void SkeletalModel::Draw(ComPtr<ID3D11DeviceContext>& pDeviceContext, ComPtr<ID3D11Buffer>& pMatBuffer)
+{
+	m_deviceContext->UpdateSubresource(m_bonePoseBuffer.Get(), 0, nullptr, &m_BonePoses, 0, 0);
+	m_deviceContext->UpdateSubresource(m_boneOffsetBuffer.Get(), 0, nullptr, &modelAsset->m_BoneOffsets, 0, 0);
+
+	m_deviceContext->VSSetConstantBuffers(3, 1, m_bonePoseBuffer.GetAddressOf());
+	m_deviceContext->VSSetConstantBuffers(4, 1, m_boneOffsetBuffer.GetAddressOf());
+
+	TransformBuffer tb = {};
+
+	tb.isRigid = modelAsset->skeletalInfo.IsRigid();
+	m_world = m_world.CreateScale(m_Scale) *
+			  m_world.CreateFromYawPitchRoll(m_Rotation) *
+			  m_world.CreateTranslation(m_Position);
+	tb.world = XMMatrixTranspose(m_world);
+
+	int size = modelAsset->meshes.size();
+	for (size_t i = 0; i < size; i++)
+	{
+		Material meshMaterial = modelAsset->meshes[i].GetMaterial();
+		m_deviceContext->UpdateSubresource(pMatBuffer.Get(), 0, nullptr, &meshMaterial, 0, 0);		
+
+		tb.refBoneIndex = modelAsset->meshes[i].refBoneIndex;
+		
+		m_deviceContext->UpdateSubresource(m_transformBuffer.Get(), 0, nullptr, &tb, 0, 0);
+		m_deviceContext->VSSetConstantBuffers(2, 1, m_transformBuffer.GetAddressOf());
+		m_deviceContext->PSSetConstantBuffers(1, 1, pMatBuffer.GetAddressOf());
+
+		modelAsset->meshes[i].Draw(pDeviceContext);
+	}
+}
+
+void SkeletalModel::Update()
+{
+	if (!modelAsset->animations.empty() && isAnimPlay)
+	{
+		m_progressAnimationTime += GameTimer::m_Instance->DeltaTime();
+		m_progressAnimationTime = fmod(m_progressAnimationTime, modelAsset->animations[m_animationIndex].m_duration);
+	}
+
+	// pose 본 갱신
+	for (auto& bone : m_bones)
+	{
+		// 애니메이션 업데이트
+		if (bone.m_boneAnimation.m_boneName != "")
+		{
+			Vector3 positionVec = Vector3::Zero;
+			Vector3 scaleVec = Vector3::Zero;
+			Quaternion rotationQuat = Quaternion::Identity;
+			bone.m_boneAnimation.Evaluate(m_progressAnimationTime, positionVec, rotationQuat, scaleVec);
+
+			if (positionVec != Vector3::Zero || rotationQuat != Quaternion::Identity || scaleVec != Vector3::Zero) // 움직이지 않는 본들은 갱신 안함
+			{
+				Matrix mat = Matrix::CreateScale(scaleVec) * Matrix::CreateFromQuaternion(rotationQuat) * Matrix::CreateTranslation(positionVec);
+				bone.m_localTransform = mat.Transpose();
+			}
+		}
+
+		// 위치 갱신
+		if (bone.m_parentIndex != -1)
+		{
+			bone.m_worldTransform = m_bones[bone.m_parentIndex].m_worldTransform * bone.m_localTransform;
+		}
+		else
+		{
+			bone.m_worldTransform = bone.m_localTransform;
+		}
+
+		m_BonePoses.modelMatricies[bone.m_index] = bone.m_worldTransform;
+	}	
+}
+
+void SkeletalModel::Close()
+{
+}
+
+void SkeletalModel::GetBuffer(ComPtr<ID3D11Buffer>& pTransform, ComPtr<ID3D11Buffer>& pBonePose, ComPtr<ID3D11Buffer>& pBoneOffset)
+{
+	m_transformBuffer = pTransform;
+	m_bonePoseBuffer = pBonePose;
+	m_boneOffsetBuffer = pBoneOffset;
+}
+
+void SkeletalModel::CreateBoneInfos()
+{
+	int size = modelAsset->skeletalInfo.m_bones.size();
+	for (int i = 0; i < size; i++)
+	{
+		string boneName = modelAsset->skeletalInfo.m_bones[i].name;
+		BoneInfo boneInfo = modelAsset->skeletalInfo.GetBoneInfoByName(boneName);
+		int boneIndex = modelAsset->skeletalInfo.GetBoneIndexByName(boneName);
+
+		string parentBoneName = boneInfo.parentBoneName;
+		BoneInfo parentBoneInfo;
+		int parentBoneIndex = -1;
+		if (parentBoneName != "")
+		{
+			parentBoneInfo = modelAsset->skeletalInfo.GetBoneInfoByName(parentBoneName);
+			parentBoneIndex = modelAsset->skeletalInfo.GetBoneIndexByName(parentBoneName);
+		}
+
+		Matrix localMat = boneInfo.relativeTransform;
+		Matrix worldMat = parentBoneIndex > 0 ? m_bones[parentBoneIndex].m_worldTransform * localMat : localMat;
+
+		// Bone 정보 생성
+		Bone bone;
+		bone.CreateBone(boneName, parentBoneIndex, boneIndex, worldMat, localMat);	//...
+
+		BoneAnimation boneAnim;
+		bool hasAnim = !modelAsset->animations.empty();
+		if (parentBoneIndex != -1 && hasAnim)
+		{
+			modelAsset->animations[m_animationIndex].GetBoneAnimationByName(boneName, boneAnim);
+			bone.m_boneAnimation = boneAnim;	// 임시 -> 0번째 애니메이션 받기
+		}
+
+		m_bones.push_back(bone); // -> 할당 겁나됨
+	}
+}

--- a/D3D11_1/21_ResizeScreen/SkeletalModel.h
+++ b/D3D11_1/21_ResizeScreen/SkeletalModel.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <vector>
+#include <d3d11_1.h>
+#include <DirectXMath.h>
+#include <map>
+
+#include <assimp\Importer.hpp>
+#include <assimp\scene.h>
+#include <assimp\postprocess.h>
+
+#include "Mesh.h"
+#include "TextureLoader.h"
+#include "SkeletonInfo.h"
+#include "Animation.h"
+#include "Bone.h"
+#include "FBXResourceManager.h"
+
+struct BonePoseBuffer
+{
+	Matrix modelMatricies[256];
+};
+
+/// <summary>
+/// 모델에서 사용할 트랜스폼 상수 버퍼 구조체
+/// </summary>
+struct TransformBuffer
+{
+	Matrix world;
+
+	UINT isRigid;		// 1 : rigid, 0 : skinned
+	UINT refBoneIndex;	// 리지드일 때 참조하는 본 인덱스
+	FLOAT pad1;
+	FLOAT pad2;
+};
+
+class SkeletalModel
+{
+public:
+	SkeletalModel();
+	~SkeletalModel();
+
+	Matrix m_world{};
+	Vector3 m_Position{ 0.0f, 0.0f, 10.0f };
+	Vector3 m_Rotation{};
+	Vector3 m_Scale{ 1.0f, 1.0f, 1.0f };
+	bool isRemoved = false;
+
+	bool Load(HWND hwnd, ComPtr<ID3D11Device>& pDevice, ComPtr<ID3D11DeviceContext>& pDeviceContext, std::string filename);
+	void Draw(ComPtr<ID3D11DeviceContext>& pDeviceContext, ComPtr<ID3D11Buffer>& pMatBuffer);
+	void Update();
+
+	void Close();
+
+	// 애니메이션 관련 내용 - 디버그를 위해 public으로 옮김
+	int m_animationIndex = 0;				// 실행 중인 애니메이션 인덱스
+	float m_progressAnimationTime = 0.0f;		// 현재 애니메이션 시간 
+
+	bool isAnimPlay = true;
+
+	// 리소스 데이터
+	shared_ptr<FBXResourceAsset> modelAsset{};
+
+	void GetBuffer(ComPtr<ID3D11Buffer>& pTransform, ComPtr<ID3D11Buffer>& pBonePose, ComPtr<ID3D11Buffer>& pBoneOffset);
+
+private:
+	ComPtr<ID3D11Device> m_device = nullptr;
+	ComPtr<ID3D11DeviceContext> m_deviceContext = nullptr;
+	HWND hwnd{};
+
+	// 인스턴스 데이터
+	std::string directory{};				// 로드한 파일이 위차한 폴더명
+	std::vector<Bone> m_bones{};				// 로드된 모델의 본 모음 -> 계층 구조에 있는 오브젝트들
+
+	// 해당 모델의 상수 버퍼 내용
+	BonePoseBuffer m_BonePoses{};
+
+	// 버퍼들 -> App에서 참조
+	ComPtr<ID3D11Buffer> m_transformBuffer{};
+	ComPtr<ID3D11Buffer> m_bonePoseBuffer{};
+	ComPtr<ID3D11Buffer> m_boneOffsetBuffer{};
+
+	// 기능 함수
+	void CreateBoneInfos();
+};
+

--- a/D3D11_1/21_ResizeScreen/SkeletonInfo.cpp
+++ b/D3D11_1/21_ResizeScreen/SkeletonInfo.cpp
@@ -1,0 +1,103 @@
+#include "SkeletonInfo.h"
+#include <iostream>
+
+BoneInfo SkeletonInfo::GetBoneInfoByIndex(int index)
+{
+    if (index < 0 || index >= m_bones.size())
+        throw std::out_of_range("Bone index not Found" + index);
+
+    return m_bones[index];
+}
+
+BoneInfo SkeletonInfo::GetBoneInfoByName(const string& boneName)
+{
+    auto mappedInfo = m_boneMappingTable.find(boneName);
+    if (mappedInfo == m_boneMappingTable.end()) 
+        throw std::out_of_range("Bone name not Found " + boneName);
+
+    return m_bones[mappedInfo->second];
+}
+
+int SkeletonInfo::GetBoneIndexByName(const string& boneName)
+{
+	auto mappedInfo = m_boneMappingTable.find(boneName);
+	if (mappedInfo == m_boneMappingTable.end())
+		throw std::out_of_range("Bone name not Found " + boneName);
+
+	return mappedInfo->second;
+}
+
+Matrix SkeletonInfo::GetBoneOffsetByName(const string& boneName)
+{
+	auto mappedInfo = m_bonesOffset.find(boneName);
+	if (mappedInfo == m_bonesOffset.end())
+		return Matrix::Identity;
+
+	return mappedInfo->second;
+}
+
+bool SkeletonInfo::CreateFromAiScene(const aiScene* pAiScene)
+{
+	if (pAiScene == nullptr) return false;
+
+	aiNode* pRootNode = pAiScene->mRootNode;
+
+	CreateBoneInfoFromNode(pRootNode);	
+
+	UINT meshNum = pAiScene->mNumMeshes;
+	for (int i = 0; i < meshNum; i++)
+	{
+		aiMesh* pMesh = pAiScene->mMeshes[i];
+		UINT boneNum = pMesh->mNumBones;
+
+		if (boneNum > 0) isRigid = false;
+
+		for (int j = 0; j < boneNum; j++)
+		{
+			aiBone* pBone = pMesh->mBones[j];
+			string name = pBone->mName.C_Str();
+			Matrix offsetMat = { pBone->mOffsetMatrix.a1, pBone->mOffsetMatrix.a2, pBone->mOffsetMatrix.a3, pBone->mOffsetMatrix.a4,
+								 pBone->mOffsetMatrix.b1, pBone->mOffsetMatrix.b2, pBone->mOffsetMatrix.b3, pBone->mOffsetMatrix.b4,
+								 pBone->mOffsetMatrix.c1, pBone->mOffsetMatrix.c2, pBone->mOffsetMatrix.c3, pBone->mOffsetMatrix.c4,
+								 pBone->mOffsetMatrix.d1, pBone->mOffsetMatrix.d2, pBone->mOffsetMatrix.d3, pBone->mOffsetMatrix.d4 };
+
+			m_bonesOffset.insert({ name, offsetMat });
+		}
+	}
+
+    return true;
+}
+
+void SkeletonInfo::CreateBoneInfoFromNode(const aiNode* pAiNode)
+{
+	aiNode* parentNode = pAiNode->mParent;
+	string parentBoneName = parentNode != nullptr ? parentNode->mName.C_Str() : "";
+	string currentBoneName = pAiNode->mName.C_Str();
+
+	BoneInfo parentBoneInfo{};
+	int parentBoneIndex = -1;
+	if (parentNode != nullptr)
+	{
+		parentBoneInfo = GetBoneInfoByName(parentBoneName);
+	}
+
+	Matrix localMat = Matrix(pAiNode->mTransformation.a1, pAiNode->mTransformation.a2, pAiNode->mTransformation.a3, pAiNode->mTransformation.a4,
+		pAiNode->mTransformation.b1, pAiNode->mTransformation.b2, pAiNode->mTransformation.b3, pAiNode->mTransformation.b4,
+		pAiNode->mTransformation.c1, pAiNode->mTransformation.c2, pAiNode->mTransformation.c3, pAiNode->mTransformation.c4,
+		pAiNode->mTransformation.d1, pAiNode->mTransformation.d2, pAiNode->mTransformation.d3, pAiNode->mTransformation.d4);
+
+	BoneInfo currInfo{};
+	currInfo.name = currentBoneName;
+	currInfo.parentBoneName = parentBoneName;
+	currInfo.relativeTransform = localMat;
+
+	m_bones.push_back(currInfo);
+	m_boneMappingTable.insert({ currentBoneName, m_bones.size() - 1 });
+
+	int currentBoneIndex = m_bones.size();
+	int childCount = pAiNode->mNumChildren;
+	for (int i = 0; i < childCount; i++)
+	{
+		CreateBoneInfoFromNode(pAiNode->mChildren[i]);
+	}
+}

--- a/D3D11_1/21_ResizeScreen/SkeletonInfo.h
+++ b/D3D11_1/21_ResizeScreen/SkeletonInfo.h
@@ -1,0 +1,45 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <map>
+
+#include <assimp\scene.h>
+#include <directxtk/SimpleMath.h>
+
+using namespace DirectX::SimpleMath;
+using namespace std;
+
+/// <summary>
+/// 본에 대한 관계 데이터
+/// </summary>
+class BoneInfo
+{
+public:
+	string name{};				// 본 이름
+	string parentBoneName{};	// 해당 본의 부모 이름 없으면 ""
+	Matrix relativeTransform{};	// 해당 본 매트릭스 값
+};
+
+/// <summary>
+/// boneInfo 매핑 데이터를 가지고 있는 클리스
+/// </summary>
+class SkeletonInfo
+{
+private:
+	map<string, int> m_boneMappingTable;
+	map<string, Matrix> m_bonesOffset;
+	bool isRigid = true;
+
+	void CreateBoneInfoFromNode(const aiNode* pAiNode);
+
+public:
+	vector<BoneInfo> m_bones;
+
+	BoneInfo GetBoneInfoByIndex(int index);
+	BoneInfo GetBoneInfoByName(const string& boneName);
+	int GetBoneIndexByName(const string& boneName);
+	Matrix GetBoneOffsetByName(const string& boneName);
+	bool CreateFromAiScene(const aiScene* pAiScene);
+
+	bool IsRigid() { return isRigid; };
+};

--- a/D3D11_1/21_ResizeScreen/TextureLoader.cpp
+++ b/D3D11_1/21_ResizeScreen/TextureLoader.cpp
@@ -1,0 +1,697 @@
+//--------------------------------------------------------------------------------------
+// File: WICTextureLoader.cpp
+//
+// Function for loading a WIC image and creating a Direct3D 11 runtime texture for it
+// (auto-generating mipmaps if possible)
+//
+// Note: Assumes application has already called CoInitializeEx
+//
+// Warning: CreateWICTexture* functions are not thread-safe if given a d3dContext instance for
+//          auto-gen mipmap support.
+//
+// Note these functions are useful for images created as simple 2D textures. For
+// more complex resources, DDSTextureLoader is an excellent light-weight runtime loader.
+// For a full-featured DDS file reader, writer, and texture processing pipeline see
+// the 'Texconv' sample and the 'DirectXTex' library.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+// PARTICULAR PURPOSE.
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+// http://go.microsoft.com/fwlink/?LinkId=248929
+//--------------------------------------------------------------------------------------
+
+// We could load multi-frame images (TIFF/GIF) into a texture array.
+// For now, we just load the first frame (note: DirectXTex supports multi-frame images)
+
+#include <dxgiformat.h>
+#include <assert.h>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4005)
+#endif // _MSC_VER
+
+#include <wincodec.h>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
+
+#include <memory>
+
+#include "TextureLoader.h"
+
+#if (_WIN32_WINNT >= 0x0602 /*_WIN32_WINNT_WIN8*/) && !defined(DXGI_1_2_FORMATS)
+#define DXGI_1_2_FORMATS
+#endif
+
+//---------------------------------------------------------------------------------
+template<class T> class ScopedObject
+{
+public:
+	explicit ScopedObject(T *p = 0) : _pointer(p) {}
+	~ScopedObject()
+	{
+		if (_pointer)
+		{
+			_pointer->Release();
+			_pointer = nullptr;
+		}
+	}
+
+	bool IsNull() const { return (!_pointer); }
+
+	T& operator*() { return *_pointer; }
+	T* operator->() { return _pointer; }
+	T** operator&() { return &_pointer; }
+
+	void Reset(T *p = 0) { if (_pointer) { _pointer->Release(); } _pointer = p; }
+
+	T* Get() const { return _pointer; }
+
+private:
+	ScopedObject(const ScopedObject&);
+	ScopedObject& operator=(const ScopedObject&);
+
+	T* _pointer;
+};
+
+//-------------------------------------------------------------------------------------
+// WIC Pixel Format Translation Data
+//-------------------------------------------------------------------------------------
+struct WICTranslate
+{
+	GUID                wic;
+	DXGI_FORMAT         format;
+};
+
+static WICTranslate g_WICFormats[] =
+{
+	{ GUID_WICPixelFormat128bppRGBAFloat,       DXGI_FORMAT_R32G32B32A32_FLOAT },
+
+	{ GUID_WICPixelFormat64bppRGBAHalf,         DXGI_FORMAT_R16G16B16A16_FLOAT },
+	{ GUID_WICPixelFormat64bppRGBA,             DXGI_FORMAT_R16G16B16A16_UNORM },
+
+	{ GUID_WICPixelFormat32bppRGBA,             DXGI_FORMAT_R8G8B8A8_UNORM },
+	{ GUID_WICPixelFormat32bppBGRA,             DXGI_FORMAT_B8G8R8A8_UNORM }, // DXGI 1.1
+	{ GUID_WICPixelFormat32bppBGR,              DXGI_FORMAT_B8G8R8X8_UNORM }, // DXGI 1.1
+
+	{ GUID_WICPixelFormat32bppRGBA1010102XR,    DXGI_FORMAT_R10G10B10_XR_BIAS_A2_UNORM }, // DXGI 1.1
+	{ GUID_WICPixelFormat32bppRGBA1010102,      DXGI_FORMAT_R10G10B10A2_UNORM },
+	{ GUID_WICPixelFormat32bppRGBE,             DXGI_FORMAT_R9G9B9E5_SHAREDEXP },
+
+#ifdef DXGI_1_2_FORMATS
+
+	{ GUID_WICPixelFormat16bppBGRA5551,         DXGI_FORMAT_B5G5R5A1_UNORM },
+	{ GUID_WICPixelFormat16bppBGR565,           DXGI_FORMAT_B5G6R5_UNORM },
+
+#endif // DXGI_1_2_FORMATS
+
+	{ GUID_WICPixelFormat32bppGrayFloat,        DXGI_FORMAT_R32_FLOAT },
+	{ GUID_WICPixelFormat16bppGrayHalf,         DXGI_FORMAT_R16_FLOAT },
+	{ GUID_WICPixelFormat16bppGray,             DXGI_FORMAT_R16_UNORM },
+	{ GUID_WICPixelFormat8bppGray,              DXGI_FORMAT_R8_UNORM },
+
+	{ GUID_WICPixelFormat8bppAlpha,             DXGI_FORMAT_A8_UNORM },
+
+#if (_WIN32_WINNT >= 0x0602 /*_WIN32_WINNT_WIN8*/)
+	{ GUID_WICPixelFormat96bppRGBFloat,         DXGI_FORMAT_R32G32B32_FLOAT },
+#endif
+};
+
+//-------------------------------------------------------------------------------------
+// WIC Pixel Format nearest conversion table
+//-------------------------------------------------------------------------------------
+
+struct WICConvert
+{
+	GUID        source;
+	GUID        target;
+};
+
+static WICConvert g_WICConvert[] =
+{
+	// Note target GUID in this conversion table must be one of those directly supported formats (above).
+
+	{ GUID_WICPixelFormatBlackWhite,            GUID_WICPixelFormat8bppGray }, // DXGI_FORMAT_R8_UNORM
+
+	{ GUID_WICPixelFormat1bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat2bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat4bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat8bppIndexed,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+
+	{ GUID_WICPixelFormat2bppGray,              GUID_WICPixelFormat8bppGray }, // DXGI_FORMAT_R8_UNORM
+	{ GUID_WICPixelFormat4bppGray,              GUID_WICPixelFormat8bppGray }, // DXGI_FORMAT_R8_UNORM
+
+	{ GUID_WICPixelFormat16bppGrayFixedPoint,   GUID_WICPixelFormat16bppGrayHalf }, // DXGI_FORMAT_R16_FLOAT
+	{ GUID_WICPixelFormat32bppGrayFixedPoint,   GUID_WICPixelFormat32bppGrayFloat }, // DXGI_FORMAT_R32_FLOAT
+
+#ifdef DXGI_1_2_FORMATS
+
+	{ GUID_WICPixelFormat16bppBGR555,           GUID_WICPixelFormat16bppBGRA5551 }, // DXGI_FORMAT_B5G5R5A1_UNORM
+
+#else
+
+	{ GUID_WICPixelFormat16bppBGR555,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat16bppBGRA5551,         GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat16bppBGR565,           GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+
+#endif // DXGI_1_2_FORMATS
+
+	{ GUID_WICPixelFormat32bppBGR101010,        GUID_WICPixelFormat32bppRGBA1010102 }, // DXGI_FORMAT_R10G10B10A2_UNORM
+
+	{ GUID_WICPixelFormat24bppBGR,              GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat24bppRGB,              GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat32bppPBGRA,            GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat32bppPRGBA,            GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+
+	{ GUID_WICPixelFormat48bppRGB,              GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat48bppBGR,              GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat64bppBGRA,             GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat64bppPRGBA,            GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat64bppPBGRA,            GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+
+	{ GUID_WICPixelFormat48bppRGBFixedPoint,    GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT
+	{ GUID_WICPixelFormat48bppBGRFixedPoint,    GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT
+	{ GUID_WICPixelFormat64bppRGBAFixedPoint,   GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT
+	{ GUID_WICPixelFormat64bppBGRAFixedPoint,   GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT
+	{ GUID_WICPixelFormat64bppRGBFixedPoint,    GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT
+	{ GUID_WICPixelFormat64bppRGBHalf,          GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT
+	{ GUID_WICPixelFormat48bppRGBHalf,          GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT
+
+	{ GUID_WICPixelFormat96bppRGBFixedPoint,    GUID_WICPixelFormat128bppRGBAFloat }, // DXGI_FORMAT_R32G32B32A32_FLOAT
+	{ GUID_WICPixelFormat128bppPRGBAFloat,      GUID_WICPixelFormat128bppRGBAFloat }, // DXGI_FORMAT_R32G32B32A32_FLOAT
+	{ GUID_WICPixelFormat128bppRGBFloat,        GUID_WICPixelFormat128bppRGBAFloat }, // DXGI_FORMAT_R32G32B32A32_FLOAT
+	{ GUID_WICPixelFormat128bppRGBAFixedPoint,  GUID_WICPixelFormat128bppRGBAFloat }, // DXGI_FORMAT_R32G32B32A32_FLOAT
+	{ GUID_WICPixelFormat128bppRGBFixedPoint,   GUID_WICPixelFormat128bppRGBAFloat }, // DXGI_FORMAT_R32G32B32A32_FLOAT
+
+	{ GUID_WICPixelFormat32bppCMYK,             GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat64bppCMYK,             GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat40bppCMYKAlpha,        GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat80bppCMYKAlpha,        GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+
+#if (_WIN32_WINNT >= 0x0602 /*_WIN32_WINNT_WIN8*/)
+	{ GUID_WICPixelFormat32bppRGB,              GUID_WICPixelFormat32bppRGBA }, // DXGI_FORMAT_R8G8B8A8_UNORM
+	{ GUID_WICPixelFormat64bppRGB,              GUID_WICPixelFormat64bppRGBA }, // DXGI_FORMAT_R16G16B16A16_UNORM
+	{ GUID_WICPixelFormat64bppPRGBAHalf,        GUID_WICPixelFormat64bppRGBAHalf }, // DXGI_FORMAT_R16G16B16A16_FLOAT
+#endif
+
+																					// We don't support n-channel formats
+};
+
+//--------------------------------------------------------------------------------------
+static IWICImagingFactory* _GetWIC()
+{
+	static IWICImagingFactory* s_Factory = nullptr;
+
+	if (s_Factory)
+		return s_Factory;
+
+	HRESULT hr = CoCreateInstance(
+		CLSID_WICImagingFactory,
+		nullptr,
+		CLSCTX_INPROC_SERVER,
+		__uuidof(IWICImagingFactory),
+		(LPVOID*)&s_Factory
+	);
+
+	if (FAILED(hr))
+	{
+		s_Factory = nullptr;
+		return nullptr;
+	}
+
+	return s_Factory;
+}
+
+//---------------------------------------------------------------------------------
+static DXGI_FORMAT _WICToDXGI(const GUID& guid)
+{
+	for (size_t i = 0; i < _countof(g_WICFormats); ++i)
+	{
+		if (memcmp(&g_WICFormats[i].wic, &guid, sizeof(GUID)) == 0)
+			return g_WICFormats[i].format;
+	}
+
+	return DXGI_FORMAT_UNKNOWN;
+}
+
+//---------------------------------------------------------------------------------
+static size_t _WICBitsPerPixel(REFGUID targetGuid)
+{
+	IWICImagingFactory* pWIC = _GetWIC();
+	if (!pWIC)
+		return 0;
+
+	ScopedObject<IWICComponentInfo> cinfo;
+	if (FAILED(pWIC->CreateComponentInfo(targetGuid, &cinfo)))
+		return 0;
+
+	WICComponentType type;
+	if (FAILED(cinfo->GetComponentType(&type)))
+		return 0;
+
+	if (type != WICPixelFormat)
+		return 0;
+
+	ScopedObject<IWICPixelFormatInfo> pfinfo;
+	if (FAILED(cinfo->QueryInterface(__uuidof(IWICPixelFormatInfo), reinterpret_cast<void**>(&pfinfo))))
+		return 0;
+
+	UINT bpp;
+	if (FAILED(pfinfo->GetBitsPerPixel(&bpp)))
+		return 0;
+
+	return bpp;
+}
+
+//---------------------------------------------------------------------------------
+static HRESULT CreateTextureFromWIC(_In_ ID3D11Device* d3dDevice,
+	_In_opt_ ID3D11DeviceContext* d3dContext,
+	_In_ IWICBitmapFrameDecode *frame,
+	_Out_opt_ ID3D11Resource** texture,
+	_Out_opt_ ID3D11ShaderResourceView** textureView,
+	_In_ size_t maxsize)
+{
+	UINT width, height;
+	HRESULT hr = frame->GetSize(&width, &height);
+	if (FAILED(hr))
+		return hr;
+
+	assert(width > 0 && height > 0);
+
+	if (!maxsize)
+	{
+		// This is a bit conservative because the hardware could support larger textures than
+		// the Feature Level defined minimums, but doing it this way is much easier and more
+		// performant for WIC than the 'fail and retry' model used by DDSTextureLoader
+
+		switch (d3dDevice->GetFeatureLevel())
+		{
+		case D3D_FEATURE_LEVEL_9_1:
+		case D3D_FEATURE_LEVEL_9_2:
+			maxsize = 2048 /*D3D_FL9_1_REQ_TEXTURE2D_U_OR_V_DIMENSION*/;
+			break;
+
+		case D3D_FEATURE_LEVEL_9_3:
+			maxsize = 4096 /*D3D_FL9_3_REQ_TEXTURE2D_U_OR_V_DIMENSION*/;
+			break;
+
+		case D3D_FEATURE_LEVEL_10_0:
+		case D3D_FEATURE_LEVEL_10_1:
+			maxsize = 8192 /*D3D10_REQ_TEXTURE2D_U_OR_V_DIMENSION*/;
+			break;
+
+		default:
+			maxsize = D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION;
+			break;
+		}
+	}
+
+	assert(maxsize > 0);
+
+	UINT twidth, theight;
+	if (width > maxsize || height > maxsize)
+	{
+		float ar = static_cast<float>(height) / static_cast<float>(width);
+		if (width > height)
+		{
+			twidth = static_cast<UINT>(maxsize);
+			theight = static_cast<UINT>(static_cast<float>(maxsize) * ar);
+		}
+		else
+		{
+			theight = static_cast<UINT>(maxsize);
+			twidth = static_cast<UINT>(static_cast<float>(maxsize) / ar);
+		}
+		assert(twidth <= maxsize && theight <= maxsize);
+	}
+	else
+	{
+		twidth = width;
+		theight = height;
+	}
+
+	// Determine format
+	WICPixelFormatGUID pixelFormat;
+	hr = frame->GetPixelFormat(&pixelFormat);
+	if (FAILED(hr))
+		return hr;
+
+	WICPixelFormatGUID convertGUID;
+	memcpy(&convertGUID, &pixelFormat, sizeof(WICPixelFormatGUID));
+
+	size_t bpp = 0;
+
+	DXGI_FORMAT format = _WICToDXGI(pixelFormat);
+	if (format == DXGI_FORMAT_UNKNOWN)
+	{
+		for (size_t i = 0; i < _countof(g_WICConvert); ++i)
+		{
+			if (memcmp(&g_WICConvert[i].source, &pixelFormat, sizeof(WICPixelFormatGUID)) == 0)
+			{
+				memcpy(&convertGUID, &g_WICConvert[i].target, sizeof(WICPixelFormatGUID));
+
+				format = _WICToDXGI(g_WICConvert[i].target);
+				assert(format != DXGI_FORMAT_UNKNOWN);
+				bpp = _WICBitsPerPixel(convertGUID);
+				break;
+			}
+		}
+
+		if (format == DXGI_FORMAT_UNKNOWN)
+			return HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
+	}
+	else
+	{
+		bpp = _WICBitsPerPixel(pixelFormat);
+	}
+
+	if (!bpp)
+		return E_FAIL;
+
+	// Verify our target format is supported by the current device
+	// (handles WDDM 1.0 or WDDM 1.1 device driver cases as well as DirectX 11.0 Runtime without 16bpp format support)
+	UINT support = 0;
+	hr = d3dDevice->CheckFormatSupport(format, &support);
+	if (FAILED(hr) || !(support & D3D11_FORMAT_SUPPORT_TEXTURE2D))
+	{
+		// Fallback to RGBA 32-bit format which is supported by all devices
+		memcpy(&convertGUID, &GUID_WICPixelFormat32bppRGBA, sizeof(WICPixelFormatGUID));
+		format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		bpp = 32;
+	}
+
+	// Allocate temporary memory for image
+	size_t rowPitch = (twidth * bpp + 7) / 8;
+	size_t imageSize = rowPitch * theight;
+
+	std::unique_ptr<uint8_t[]> temp(new uint8_t[imageSize]);
+
+	// Load image data
+	if (memcmp(&convertGUID, &pixelFormat, sizeof(GUID)) == 0
+		&& twidth == width
+		&& theight == height)
+	{
+		// No format conversion or resize needed
+		hr = frame->CopyPixels(0, static_cast<UINT>(rowPitch), static_cast<UINT>(imageSize), temp.get());
+		if (FAILED(hr))
+			return hr;
+	}
+	else if (twidth != width || theight != height)
+	{
+		// Resize
+		IWICImagingFactory* pWIC = _GetWIC();
+		if (!pWIC)
+			return E_NOINTERFACE;
+
+		ScopedObject<IWICBitmapScaler> scaler;
+		hr = pWIC->CreateBitmapScaler(&scaler);
+		if (FAILED(hr))
+			return hr;
+
+		hr = scaler->Initialize(frame, twidth, theight, WICBitmapInterpolationModeFant);
+		if (FAILED(hr))
+			return hr;
+
+		WICPixelFormatGUID pfScaler;
+		hr = scaler->GetPixelFormat(&pfScaler);
+		if (FAILED(hr))
+			return hr;
+
+		if (memcmp(&convertGUID, &pfScaler, sizeof(GUID)) == 0)
+		{
+			// No format conversion needed
+			hr = scaler->CopyPixels(0, static_cast<UINT>(rowPitch), static_cast<UINT>(imageSize), temp.get());
+			if (FAILED(hr))
+				return hr;
+		}
+		else
+		{
+			ScopedObject<IWICFormatConverter> FC;
+			hr = pWIC->CreateFormatConverter(&FC);
+			if (FAILED(hr))
+				return hr;
+
+			hr = FC->Initialize(scaler.Get(), convertGUID, WICBitmapDitherTypeErrorDiffusion, 0, 0, WICBitmapPaletteTypeCustom);
+			if (FAILED(hr))
+				return hr;
+
+			hr = FC->CopyPixels(0, static_cast<UINT>(rowPitch), static_cast<UINT>(imageSize), temp.get());
+			if (FAILED(hr))
+				return hr;
+		}
+	}
+	else
+	{
+		// Format conversion but no resize
+		IWICImagingFactory* pWIC = _GetWIC();
+		if (!pWIC)
+			return E_NOINTERFACE;
+
+		ScopedObject<IWICFormatConverter> FC;
+		hr = pWIC->CreateFormatConverter(&FC);
+		if (FAILED(hr))
+			return hr;
+
+		hr = FC->Initialize(frame, convertGUID, WICBitmapDitherTypeErrorDiffusion, 0, 0, WICBitmapPaletteTypeCustom);
+		if (FAILED(hr))
+			return hr;
+
+		hr = FC->CopyPixels(0, static_cast<UINT>(rowPitch), static_cast<UINT>(imageSize), temp.get());
+		if (FAILED(hr))
+			return hr;
+	}
+
+	// See if format is supported for auto-gen mipmaps (varies by feature level)
+	bool autogen = false;
+	if (d3dContext != 0 && textureView != 0) // Must have context and shader-view to auto generate mipmaps
+	{
+		UINT fmtSupport = 0;
+		hr = d3dDevice->CheckFormatSupport(format, &fmtSupport);
+		if (SUCCEEDED(hr) && (fmtSupport & D3D11_FORMAT_SUPPORT_MIP_AUTOGEN))
+		{
+			autogen = true;
+		}
+	}
+
+	// Create texture
+	D3D11_TEXTURE2D_DESC desc;
+	desc.Width = twidth;
+	desc.Height = theight;
+	desc.MipLevels = (autogen) ? 0 : 1;
+	desc.ArraySize = 1;
+	desc.Format = format;
+	desc.SampleDesc.Count = 1;
+	desc.SampleDesc.Quality = 0;
+	desc.Usage = D3D11_USAGE_DEFAULT;
+	desc.BindFlags = (autogen) ? (D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET) : (D3D11_BIND_SHADER_RESOURCE);
+	desc.CPUAccessFlags = 0;
+	desc.MiscFlags = (autogen) ? D3D11_RESOURCE_MISC_GENERATE_MIPS : 0;
+
+	D3D11_SUBRESOURCE_DATA initData;
+	initData.pSysMem = temp.get();
+	initData.SysMemPitch = static_cast<UINT>(rowPitch);
+	initData.SysMemSlicePitch = static_cast<UINT>(imageSize);
+
+	ID3D11Texture2D* tex = nullptr;
+	hr = d3dDevice->CreateTexture2D(&desc, (autogen) ? nullptr : &initData, &tex);
+	if (SUCCEEDED(hr) && tex != 0)
+	{
+		if (textureView != 0)
+		{
+			D3D11_SHADER_RESOURCE_VIEW_DESC SRVDesc;
+			memset(&SRVDesc, 0, sizeof(SRVDesc));
+			SRVDesc.Format = format;
+			SRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+			SRVDesc.Texture2D.MipLevels = (autogen) ? -1 : 1;
+
+			hr = d3dDevice->CreateShaderResourceView(tex, &SRVDesc, textureView);
+			if (FAILED(hr))
+			{
+				tex->Release();
+				return hr;
+			}
+
+			if (autogen)
+			{
+				assert(d3dContext != 0);
+				d3dContext->UpdateSubresource(tex, 0, nullptr, temp.get(), static_cast<UINT>(rowPitch), static_cast<UINT>(imageSize));
+				d3dContext->GenerateMips(*textureView);
+			}
+		}
+
+		if (texture != 0)
+		{
+			*texture = tex;
+		}
+		else
+		{
+#if defined(_DEBUG) || defined(PROFILE)
+			tex->SetPrivateData(WKPDID_D3DDebugObjectName,
+				sizeof("WICTextureLoader") - 1,
+				"WICTextureLoader"
+			);
+#endif
+			tex->Release();
+		}
+	}
+
+	return hr;
+}
+
+//--------------------------------------------------------------------------------------
+HRESULT CreateWICTextureFromMemory(_In_ ID3D11Device* d3dDevice,
+	_In_opt_ ID3D11DeviceContext* d3dContext,
+	_In_bytecount_(wicDataSize) const uint8_t* wicData,
+	_In_ size_t wicDataSize,
+	_Out_opt_ ID3D11Resource** texture,
+	_Out_opt_ ID3D11ShaderResourceView** textureView,
+	_In_ size_t maxsize
+)
+{
+	if (!d3dDevice || !wicData || (!texture && !textureView))
+	{
+		return E_INVALIDARG;
+	}
+
+	if (!wicDataSize)
+	{
+		return E_FAIL;
+	}
+
+#ifdef _M_AMD64
+	if (wicDataSize > 0xFFFFFFFF)
+		return HRESULT_FROM_WIN32(ERROR_FILE_TOO_LARGE);
+#endif
+
+	IWICImagingFactory* pWIC = _GetWIC();
+	if (!pWIC)
+		return E_NOINTERFACE;
+
+	// Create input stream for memory
+	ScopedObject<IWICStream> stream;
+	HRESULT hr = pWIC->CreateStream(&stream);
+	if (FAILED(hr))
+		return hr;
+
+	hr = stream->InitializeFromMemory(const_cast<uint8_t*>(wicData), static_cast<DWORD>(wicDataSize));
+	if (FAILED(hr))
+		return hr;
+
+	// Initialize WIC
+	ScopedObject<IWICBitmapDecoder> decoder;
+	hr = pWIC->CreateDecoderFromStream(stream.Get(), 0, WICDecodeMetadataCacheOnDemand, &decoder);
+	if (FAILED(hr))
+		return hr;
+
+	ScopedObject<IWICBitmapFrameDecode> frame;
+	hr = decoder->GetFrame(0, &frame);
+	if (FAILED(hr))
+		return hr;
+
+	hr = CreateTextureFromWIC(d3dDevice, d3dContext, frame.Get(), texture, textureView, maxsize);
+	if (FAILED(hr))
+		return hr;
+
+#if defined(_DEBUG) || defined(PROFILE)
+	if (texture != 0 && *texture != 0)
+	{
+		(*texture)->SetPrivateData(WKPDID_D3DDebugObjectName,
+			sizeof("WICTextureLoader") - 1,
+			"WICTextureLoader"
+		);
+	}
+
+	if (textureView != 0 && *textureView != 0)
+	{
+		(*textureView)->SetPrivateData(WKPDID_D3DDebugObjectName,
+			sizeof("WICTextureLoader") - 1,
+			"WICTextureLoader"
+		);
+	}
+#endif
+
+	return hr;
+}
+
+//--------------------------------------------------------------------------------------
+HRESULT CreateWICTextureFromFile(_In_ ID3D11Device* d3dDevice,
+	_In_opt_ ID3D11DeviceContext* d3dContext,
+	_In_z_ const wchar_t* fileName,
+	_Out_opt_ ID3D11Resource** texture,
+	_Out_opt_ ID3D11ShaderResourceView** textureView,
+	_In_ size_t maxsize)
+{
+	if (!d3dDevice || !fileName || (!texture && !textureView))
+	{
+		return E_INVALIDARG;
+	}
+
+	IWICImagingFactory* pWIC = _GetWIC();
+	if (!pWIC)
+		return E_NOINTERFACE;
+
+	// Initialize WIC
+	ScopedObject<IWICBitmapDecoder> decoder;
+	HRESULT hr = pWIC->CreateDecoderFromFilename(fileName, 0, GENERIC_READ, WICDecodeMetadataCacheOnDemand, &decoder);
+	if (FAILED(hr))
+		return hr;
+
+	ScopedObject<IWICBitmapFrameDecode> frame;
+	hr = decoder->GetFrame(0, &frame);
+	if (FAILED(hr))
+		return hr;
+
+	hr = CreateTextureFromWIC(d3dDevice, d3dContext, frame.Get(), texture, textureView, maxsize);
+	if (FAILED(hr))
+		return hr;
+
+#if defined(_DEBUG) || defined(PROFILE)
+	if (texture != 0 || textureView != 0)
+	{
+		CHAR strFileA[MAX_PATH];
+		WideCharToMultiByte(CP_ACP,
+			WC_NO_BEST_FIT_CHARS,
+			fileName,
+			-1,
+			strFileA,
+			MAX_PATH,
+			nullptr,
+			FALSE
+		);
+		const CHAR* pstrName = strrchr(strFileA, '\\');
+		if (!pstrName)
+		{
+			pstrName = strFileA;
+		}
+		else
+		{
+			pstrName++;
+		}
+
+		if (texture != 0 && *texture != 0)
+		{
+			(*texture)->SetPrivateData(WKPDID_D3DDebugObjectName,
+				static_cast<UINT>(strnlen_s(pstrName, MAX_PATH)),
+				pstrName
+			);
+		}
+
+		if (textureView != 0 && *textureView != 0)
+		{
+			(*textureView)->SetPrivateData(WKPDID_D3DDebugObjectName,
+				static_cast<UINT>(strnlen_s(pstrName, MAX_PATH)),
+				pstrName
+			);
+		}
+	}
+#endif
+
+	return hr;
+}

--- a/D3D11_1/21_ResizeScreen/TextureLoader.h
+++ b/D3D11_1/21_ResizeScreen/TextureLoader.h
@@ -1,0 +1,61 @@
+//--------------------------------------------------------------------------------------
+// File: WICTextureLoader.h
+//
+// Function for loading a WIC image and creating a Direct3D 11 runtime texture for it
+// (auto-generating mipmaps if possible)
+//
+// Note: Assumes application has already called CoInitializeEx
+//
+// Warning: CreateWICTexture* functions are not thread-safe if given a d3dContext instance for
+//          auto-gen mipmap support.
+//
+// Note these functions are useful for images created as simple 2D textures. For
+// more complex resources, DDSTextureLoader is an excellent light-weight runtime loader.
+// For a full-featured DDS file reader, writer, and texture processing pipeline see
+// the 'Texconv' sample and the 'DirectXTex' library.
+//
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF
+// ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
+// PARTICULAR PURPOSE.
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+// http://go.microsoft.com/fwlink/?LinkId=248929
+//--------------------------------------------------------------------------------------
+
+#ifdef _MSC_VER
+#pragma once
+#endif
+
+#include <d3d11.h>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4005)
+#endif // _MSC_VER
+
+#include <stdint.h>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
+
+HRESULT CreateWICTextureFromMemory(_In_ ID3D11Device* d3dDevice,
+	_In_opt_ ID3D11DeviceContext* d3dContext,
+	_In_bytecount_(wicDataSize) const uint8_t* wicData,
+	_In_ size_t wicDataSize,
+	_Out_opt_ ID3D11Resource** texture,
+	_Out_opt_ ID3D11ShaderResourceView** textureView,
+	_In_ size_t maxsize = 0
+);
+
+HRESULT CreateWICTextureFromFile(_In_ ID3D11Device* d3dDevice,
+	_In_opt_ ID3D11DeviceContext* d3dContext,
+	_In_z_ const wchar_t* szFileName,
+	_Out_opt_ ID3D11Resource** texture,
+	_Out_opt_ ID3D11ShaderResourceView** textureView,
+	_In_ size_t maxsize = 0
+);
+

--- a/D3D11_1/21_ResizeScreen/WinMain.cpp
+++ b/D3D11_1/21_ResizeScreen/WinMain.cpp
@@ -1,0 +1,16 @@
+#include "DeferredRenderApp.h"
+
+int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
+	_In_opt_ HINSTANCE hPrevInstance,
+	_In_ LPWSTR    lpCmdLine,
+	_In_ int       nCmdShow)
+{
+	UNREFERENCED_PARAMETER(hPrevInstance);
+	UNREFERENCED_PARAMETER(lpCmdLine);
+
+	DeferredRenderApp App(hInstance);
+	if (!App.Initialize(1440, 768))
+		return -1;
+
+	return App.Run();
+}

--- a/D3D11_1/21_ResizeScreen/readMe.md
+++ b/D3D11_1/21_ResizeScreen/readMe.md
@@ -1,0 +1,42 @@
+## 1. 프로젝트 개요
+FBX에서 불러온 데이터에서 공유 데이터를 구분하여 관리하는 리소스 매니저를 만듭니다.
+
+## 2. 핵심 기술 포인트
+
+- 애니메이션 키프레임, 머터리얼, 버텍스 버퍼, 인덱스 버퍼, 계층 구조, 본 Offset 정보를 하나의 매니저 클래스가  weak_ptr로 소유하고 외부에 shared_ptr로 전달한다.
+- IDGIDevice3::Trim() 함수로 VRAM/DRAM/pagefile.sys 리소스 제거 요청을 한다.
+
+## 3. 구현에서 중요한 지점
+
+- 기존에 FBX 파일 데이터를 리소스 데이터와 인스턴스 데이터로 구분합니다.
+    
+    ![resourceData.png](../../document/Resource/Projects/ResourceManager/resourceData.png)
+    
+
+리소스 매니저가 저장할 구조체 만들기
+
+```cpp
+struct FBXResourceAsset
+{
+	SkeletonInfo skeletalInfo;
+	std::vector<Animation> animations;
+	std::vector<Mesh> meshes;
+	std::vector<Texture> textures;
+
+	std::string directory = "";
+	BoneOffsetBuffer m_BoneOffsets{}; // skeletalInfo 본 위치 정보
+};
+```
+
+- 중복되는 내용인 애니메이션, 메쉬, 텍스처 정보를 가지고 있는 구조체를 만들어 공유 데이터를 관리합니다.
+
+## 4. 실행 결과
+
+
+https://github.com/user-attachments/assets/5a12f6ed-938b-4d50-8baa-1b8f57d57657
+
+
+## 5. 배운 점
+
+- IDXGIDevice3::Trim() 을 통해 드라이버와 런타임이 캐싱해둔 리소스를 정리하여 시스템 메모리와 GPU 메모리를 절약할 수 있다.
+- Animation, Mesh, Texutre, Bone Offset은 재활용하여 사용할 수 있다.

--- a/D3D11_1/D3D11_1.sln
+++ b/D3D11_1/D3D11_1.sln
@@ -42,6 +42,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "19_ToneMapping", "19_ToneMa
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "20_DeferredRendering", "20_DeferredRendering\20_DeferredRendering.vcxproj", "{76F5AE96-D8DE-46A7-8A9D-EA087F13F919}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "21_ResizeScreen", "21_ResizeScreen\21_ResizeScreen.vcxproj", "{0A49A7B7-B8DF-478C-9773-C47E40EBE2B7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -210,6 +212,14 @@ Global
 		{76F5AE96-D8DE-46A7-8A9D-EA087F13F919}.Release|x64.Build.0 = Release|x64
 		{76F5AE96-D8DE-46A7-8A9D-EA087F13F919}.Release|x86.ActiveCfg = Release|Win32
 		{76F5AE96-D8DE-46A7-8A9D-EA087F13F919}.Release|x86.Build.0 = Release|Win32
+		{0A49A7B7-B8DF-478C-9773-C47E40EBE2B7}.Debug|x64.ActiveCfg = Debug|x64
+		{0A49A7B7-B8DF-478C-9773-C47E40EBE2B7}.Debug|x64.Build.0 = Debug|x64
+		{0A49A7B7-B8DF-478C-9773-C47E40EBE2B7}.Debug|x86.ActiveCfg = Debug|Win32
+		{0A49A7B7-B8DF-478C-9773-C47E40EBE2B7}.Debug|x86.Build.0 = Debug|Win32
+		{0A49A7B7-B8DF-478C-9773-C47E40EBE2B7}.Release|x64.ActiveCfg = Release|x64
+		{0A49A7B7-B8DF-478C-9773-C47E40EBE2B7}.Release|x64.Build.0 = Release|x64
+		{0A49A7B7-B8DF-478C-9773-C47E40EBE2B7}.Release|x86.ActiveCfg = Release|Win32
+		{0A49A7B7-B8DF-478C-9773-C47E40EBE2B7}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### 주요내용
- ResizeScreen, ResizeResource, ResetGBuffer 추가
`WM_ENTERSIZEMOVE`에서 `WM_EXITSIZEMOVE` 이벤트를 감지할 때 새로운 클라이언트 사이즈 값을 갱신받고 위 함수를 사용합니다.

밑의 자원을 초기화합니다.
1. backbufferRTV
2. depthStencilView
3. 스왑체인
4. viewport
5. Gbuffer들
6. 카메라 Projection

### 결과물
| 리사이징 전 | 리사이징 후 |
| :-: | :-: |
|<img width="1349" height="843" alt="before" src="https://github.com/user-attachments/assets/de1b67af-8e8d-48c8-8ede-1ec40513b0a3" /> | <img width="1753" height="924" alt="after" src="https://github.com/user-attachments/assets/db1f93e3-6a8b-47f9-a42a-2008f462d12d" /> |




